### PR TITLE
feat(studio): prevent duplicate Fragment Title on card clone

### DIFF
--- a/studio/src/editor-panel.js
+++ b/studio/src/editor-panel.js
@@ -622,6 +622,7 @@ export default class EditorPanel extends LitElement {
             const confirmed = await this.promptDiscardChanges();
             if (!confirmed) return;
         }
+        this.titleClone = this.fragment.title;
         this.showCloneDialog = true;
         Store.showCloneDialog.set(true);
     }

--- a/studio/src/mas-repository.js
+++ b/studio/src/mas-repository.js
@@ -1007,6 +1007,33 @@ export class MasRepository extends LitElement {
     }
 
     /**
+     * Returns a title that is unique within the given parent folder path.
+     * If `baseTitle` is already taken, appends -1, -2, ... until a free slot is found.
+     * @param {string} baseTitle
+     * @param {string} parentPath  - DAM folder path, e.g. /content/dam/mas/nala/en_US
+     * @returns {Promise<string>}
+     */
+    async generateUniqueFragmentTitle(baseTitle, parentPath) {
+        const existingTitles = new Set();
+        const searchGen = this.aem.sites.cf.fragments.search({ path: parentPath });
+        for await (const batch of searchGen) {
+            for await (const item of batch) {
+                existingTitles.add(item.title);
+            }
+        }
+
+        if (!existingTitles.has(baseTitle)) return baseTitle;
+
+        let suffix = 1;
+        while (suffix <= 100) {
+            const candidate = `${baseTitle}-${suffix}`;
+            if (!existingTitles.has(candidate)) return candidate;
+            suffix++;
+        }
+        throw new Error(`Cannot generate unique fragment title after 100 attempts`);
+    }
+
+    /**
      * @returns {Promise<boolean>} Whether or not it was successful
      */
     async copyFragment(updatedTitle, osi, tags = []) {
@@ -1014,15 +1041,14 @@ export class MasRepository extends LitElement {
             this.operation.set(OPERATIONS.CLONE);
             const result = await this.aem.sites.cf.fragments.copy(this.fragmentInEdit);
             let savedResult = result;
-            const needsSave = (updatedTitle && updatedTitle !== result.title) || osi;
+            const desiredTitle = updatedTitle || result.title;
+            const parentPath = result.path.split('/').slice(0, -1).join('/');
+            const uniqueTitle = await this.generateUniqueFragmentTitle(desiredTitle, parentPath);
+            const needsSave = uniqueTitle !== result.title || osi;
             if (needsSave) {
-                if (updatedTitle && updatedTitle !== result.title) {
-                    result.title = updatedTitle;
-                }
+                result.title = uniqueTitle;
                 result.fields.forEach((field) => {
-                    if (osi && field.name === 'osi') {
-                        field.values = [osi];
-                    }
+                    if (osi && field.name === 'osi') field.values = [osi];
                 });
                 savedResult = await this.aem.sites.cf.fragments.save(result);
             }

--- a/studio/test/mas-repository.test.js
+++ b/studio/test/mas-repository.test.js
@@ -1491,6 +1491,74 @@ describe('MasRepository dictionary helpers', () => {
         });
     });
 
+    describe('copyFragment', () => {
+        const makeSearchStub = (sandbox, titles) => {
+            // Returns an async generator that yields one batch of items
+            const batch = titles.map((title) => ({ title }));
+            async function* searchGen() {
+                yield (async function* () {
+                    for (const item of batch) yield item;
+                })();
+            }
+            return sandbox.stub().returns(searchGen());
+        };
+
+        it('no duplicate — title returned unchanged when not present in folder', async () => {
+            const repository = createRepository();
+            repository.aem = createAemMock({
+                fragments: {
+                    search: makeSearchStub(sandbox, ['Other Card']),
+                },
+            });
+            const unique = await repository.generateUniqueFragmentTitle('My Card', '/content/dam/mas/nala/en_US');
+            expect(unique).to.equal('My Card');
+        });
+
+        it('duplicate exists — returns title-1', async () => {
+            const repository = createRepository();
+            repository.aem = createAemMock({
+                fragments: {
+                    search: makeSearchStub(sandbox, ['My Card']),
+                },
+            });
+            const unique = await repository.generateUniqueFragmentTitle('My Card', '/content/dam/mas/nala/en_US');
+            expect(unique).to.equal('My Card-1');
+        });
+
+        it('duplicate with -1 also exists — returns title-2', async () => {
+            const repository = createRepository();
+            repository.aem = createAemMock({
+                fragments: {
+                    search: makeSearchStub(sandbox, ['My Card', 'My Card-1']),
+                },
+            });
+            const unique = await repository.generateUniqueFragmentTitle('My Card', '/content/dam/mas/nala/en_US');
+            expect(unique).to.equal('My Card-2');
+        });
+
+        it('user-provided title that is unique — used as-is', async () => {
+            const repository = createRepository();
+            repository.aem = createAemMock({
+                fragments: {
+                    search: makeSearchStub(sandbox, ['Original Card']),
+                },
+            });
+            const unique = await repository.generateUniqueFragmentTitle('Brand New Title', '/content/dam/mas/nala/en_US');
+            expect(unique).to.equal('Brand New Title');
+        });
+
+        it('user-provided title that is a duplicate — suffixed', async () => {
+            const repository = createRepository();
+            repository.aem = createAemMock({
+                fragments: {
+                    search: makeSearchStub(sandbox, ['Brand New Title']),
+                },
+            });
+            const unique = await repository.generateUniqueFragmentTitle('Brand New Title', '/content/dam/mas/nala/en_US');
+            expect(unique).to.equal('Brand New Title-1');
+        });
+    });
+
     describe('deleteFragment', () => {
         it('refreshes referencing list stores after deletion to prevent stale variation rows', async () => {
             const repository = createRepository();


### PR DESCRIPTION
## Summary
- Initialize `titleClone` to the fragment's current title when the clone dialog opens in `editor-panel.js`
- Add `generateUniqueFragmentTitle()` helper to `mas-repository.js` that scans the parent folder path and auto-suffixes (`-1`, `-2`, ...) until a unique title is found
- Update `copyFragment()` to use the uniqueness check before persisting the cloned fragment

## Issue
Closes #68

## Test plan
- [ ] Clone a card whose Fragment Title already exists in the same folder — new card gets `-1` suffix
- [ ] Clone again so `-1` also exists — new card gets `-2` suffix
- [ ] Clone a card with a unique title — no suffix added
- [ ] Original card's Fragment Title is unchanged after clone
- [ ] `npm run test --workspace=studio` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)