### PR TITLE
fix(studio): remove default 'Created By' filter on Fragment view

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,0 +1,1 @@
+/Users/antonioramirez/Documents/Dev/agentic-harness/.claude

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ masStudio-*.json
 web-components/commerce.json
 web-components/mas.json
 web-components/stats.json
+
+# Agentic harness artifacts (auto-added)
+adws
+.ports.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -4132,6 +4132,7 @@
             "resolved": "https://registry.npmjs.org/@adobe/aio-lib-ims/-/aio-lib-ims-7.0.2.tgz",
             "integrity": "sha512-H4LK6fVcADPpnD6lZIzfosBAkHyOW1Yluk7MnNGs5TKM41i3NGGl/GaI/oQjDQGH4pIISK7HPU6FO0M+0+w04g==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@adobe/aio-lib-core-config": "^5",
                 "@adobe/aio-lib-core-errors": "^4",
@@ -5943,6 +5944,7 @@
             "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
             "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
                 "@azure/core-auth": "^1.10.0",
@@ -6004,6 +6006,7 @@
             "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
             "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
                 "@azure/core-auth": "^1.10.0",
@@ -9060,6 +9063,7 @@
             "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^3.0.0",
                 "@octokit/graphql": "^5.0.0",
@@ -9467,6 +9471,7 @@
             "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@mischnic/json-sourcemap": "^0.1.1",
                 "@parcel/cache": "2.16.4",
@@ -12793,7 +12798,8 @@
         },
         "node_modules/@spectrum-css/tokens": {
             "version": "14.6.0",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/@spectrum-css/typography": {
             "version": "6.2.0",
@@ -15077,6 +15083,7 @@
             "version": "22.10.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -16783,6 +16790,7 @@
             "integrity": "sha512-5BMdA/zMzLv/ahnL1ktaV46nSXorb4sU4kQPQKDhIcK8ERbx9TAbGAE+XAlCXKioNIiOrihYj6gW1d/GEfU9Zw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^16.13.0 || >=18.12.0"
             },
@@ -16842,6 +16850,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -16934,6 +16943,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -17944,6 +17954,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -19855,7 +19866,8 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
             "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/dezalgo": {
             "version": "1.0.4",
@@ -20398,6 +20410,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -23006,6 +23019,7 @@
             "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^2.4.4",
                 "@octokit/graphql": "^4.5.8",
@@ -23761,6 +23775,7 @@
             "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/external-editor": "^1.0.0",
                 "ansi-escapes": "^4.2.1",
@@ -26227,6 +26242,7 @@
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
             "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -26312,6 +26328,7 @@
             "integrity": "sha512-NlRHmUiEcxDHI7FeDlrrTZP5YFvnoS74wEf5OrQ7NAg83B2Rv3oF+FWr961I0rVdxkKbZMjq2BcV7VFWGFPkog==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": ">=18",
                 "@types/vinyl": "^2.0.12",
@@ -30369,6 +30386,7 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -31599,6 +31617,7 @@
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
             "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -31650,6 +31669,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -31756,6 +31776,7 @@
             "version": "3.4.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -31889,6 +31910,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -32560,6 +32582,7 @@
             "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
             "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/ramda"
@@ -33386,6 +33409,7 @@
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -34036,6 +34060,7 @@
             "version": "13.0.1",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.8.3",
                 "@sinonjs/fake-timers": "^9.0.0",
@@ -35642,6 +35667,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -36993,6 +37019,7 @@
             "integrity": "sha512-/+ODrTUHtlDPRH9qIC0JREH8+7nsRcjDl3Bxn2Xo/rvAaVvixH5275jHwg0C85g4QsF4P6M2ojfScPPAl+pLAg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@npmcli/arborist": "^4.0.4",
                 "are-we-there-yet": "^2.0.0",
@@ -37156,6 +37183,7 @@
             "integrity": "sha512-GftCCBs6EN8sz3BoWO1bCj8t7YBtT713d8bUgbhg9Iel5kFSqnSvCK06TYIDJAtJ51cSiWkM/YemlT0dfoFycw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^15.6.2",
                 "@types/vinyl": "^2.0.4",

--- a/studio/src/users.js
+++ b/studio/src/users.js
@@ -28,15 +28,6 @@ export async function initUsers() {
         const uniqueEditors = await loadUsers();
         Store.users.set(uniqueEditors);
 
-        Store.search.subscribe(async ({ path }) => {
-            if (path !== 'sandbox') return;
-            Store.createdByUsers.set([
-                {
-                    displayName: profile.displayName,
-                    userPrincipalName: profile.email,
-                },
-            ]);
-        });
     } catch (e) {
         console.error('Error initializing users', e);
         Store.users.set([]);


### PR DESCRIPTION
## Summary
- Removed the `Store.search.subscribe` block in `initUsers()` that auto-populated `createdByUsers` with the current user when navigating to the sandbox path
- Fragment section now loads with no filters applied by default, showing all fragments
- The "Created By" filter UI remains functional — authors can still enable it manually

## Issue
Closes #71

## Test plan
- [ ] Navigate to M@S Studio Fragment section — no "Created By" filter applied on load
- [ ] All fragments visible by default (not filtered to current user)
- [ ] Manually enabling the "Created By" filter still works correctly
- [ ] No other filters are affected