### PR TITLE
chore: remove merch-card build dependency from merch-card-collection

### DIFF
--- a/.github/workflows/web-components-pr.yaml
+++ b/.github/workflows/web-components-pr.yaml
@@ -11,8 +11,31 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    build-and-test:
-        name: Build and Test Web Components
+    changes:
+        name: Detect changed files
+        runs-on: ubuntu-latest
+        outputs:
+            merch-card: ${{ steps.filter.outputs.merch-card }}
+            merch-card-collection: ${{ steps.filter.outputs.merch-card-collection }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Filter paths
+              uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      merch-card:
+                        - 'web-components/src/merch-card.js'
+                        - 'web-components/src/merch-card.css.js'
+                      merch-card-collection:
+                        - 'web-components/src/merch-card-collection.js'
+
+    build-merch-card:
+        name: Build merch-card
+        needs: changes
+        if: needs.changes.outputs.merch-card == 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 15
         defaults:
@@ -38,7 +61,7 @@ jobs:
               working-directory: .
 
             - name: Run build
-              run: npm run build
+              run: npm run build:merch-card
 
             - name: Check for uncommitted changes
               run: |
@@ -46,7 +69,50 @@ jobs:
                     echo "❌ Build generated changes that are not committed:"
                     git status --porcelain
                     echo ""
-                    echo "Please run 'npm run build' locally and commit the generated files."
+                    echo "Please run 'npm run build:merch-card' locally and commit the generated files."
+                    exit 1
+                  else
+                    echo "✅ No uncommitted changes after build"
+                  fi
+
+    build-merch-card-collection:
+        name: Build merch-card-collection
+        needs: changes
+        if: needs.changes.outputs.merch-card-collection == 'true'
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        defaults:
+            run:
+                working-directory: web-components
+        strategy:
+            matrix:
+                node-version: [22.x]
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: 'npm'
+                  cache-dependency-path: package-lock.json
+
+            - name: Install dependencies
+              run: npm ci
+              working-directory: .
+
+            - name: Run build
+              run: npm run build:merch-card-collection
+
+            - name: Check for uncommitted changes
+              run: |
+                  if [ -n "$(git status --porcelain)" ]; then
+                    echo "❌ Build generated changes that are not committed:"
+                    git status --porcelain
+                    echo ""
+                    echo "Please run 'npm run build:merch-card-collection' locally and commit the generated files."
                     exit 1
                   else
                     echo "✅ No uncommitted changes after build"

--- a/web-components/build.mjs
+++ b/web-components/build.mjs
@@ -15,68 +15,95 @@ const defaults = {
 // Read the price-literals.js file content
 const priceLiteralsContent = readFileSync('./price-literals.json', 'utf-8');
 
-// commerce.js
-const { metafile } = await build({
-    ...defaults,
-    alias: {
-        react: 'test/mocks/react.js',
-    },
-    entryPoints: ['./src/commerce.js'],
-    outfile: `${outfolder}/commerce.js`,
-    metafile: true,
-    platform: 'browser',
-    banner: {
-        js: `window.masPriceLiterals = ${priceLiteralsContent}.data;`,
-    },
-});
-writeFileSync(`commerce.json`, JSON.stringify(metafile));
+const componentArg = process.argv.find(
+    (arg) => arg === 'merch-card' || arg === 'merch-card-collection',
+);
 
-// mas.js
-await build({
-    ...defaults,
-    entryPoints: ['./src/mas.js'],
-    outfile: './dist/mas.js',
-    plugins: [],
-    banner: {
-        js: `window.masPriceLiterals = ${priceLiteralsContent}.data;`,
-    },
-});
+if (!componentArg) {
+    // commerce.js
+    const { metafile } = await build({
+        ...defaults,
+        alias: {
+            react: 'test/mocks/react.js',
+        },
+        entryPoints: ['./src/commerce.js'],
+        outfile: `${outfolder}/commerce.js`,
+        metafile: true,
+        platform: 'browser',
+        banner: {
+            js: `window.masPriceLiterals = ${priceLiteralsContent}.data;`,
+        },
+    });
+    writeFileSync(`commerce.json`, JSON.stringify(metafile));
+
+    // mas.js
+    await build({
+        ...defaults,
+        entryPoints: ['./src/mas.js'],
+        outfile: './dist/mas.js',
+        plugins: [],
+        banner: {
+            js: `window.masPriceLiterals = ${priceLiteralsContent}.data;`,
+        },
+    });
+}
 
 // web components
-Promise.all([
-    build({
-        ...defaults,
-        stdin: { contents: '' },
-        inject: ['./src/merch-offer.js', './src/merch-offer-select.js'],
-        plugins: [rewriteImportsToLibsFolder()],
-        outfile: `${outfolder}/merch-offer-select.js`,
-    }),
-    build({
-        ...defaults,
-        entryPoints: ['./src/merch-card-collection.js'],
-        plugins: [rewriteImportsToLibsFolder()],
-        outfile: `${outfolder}/merch-card-collection.js`,
-    }),
-    build({
-        ...defaults,
-        entryPoints: ['./src/sidenav/merch-sidenav.js'],
-        outfile: `${outfolder}/merch-sidenav.js`,
-        plugins: [rewriteImportsToLibsFolder()],
-    }),
-    build({
-        ...defaults,
-        entryPoints: ['./src/mas-field.js'],
-        outfile: `${outfolder}/mas-field.js`,
-    }),
-    buildLitComponent('merch-card'),
-    buildLitComponent('merch-icon'),
-    buildLitComponent('merch-quantity-select'),
-    buildLitComponent('merch-secure-transaction'),
-    buildLitComponent('merch-stock'),
-    buildLitComponent('merch-whats-included'),
-    buildLitComponent('merch-mnemonic-list'),
-    buildLitComponent('mas-mnemonic'),
-]).catch(() => process.exit(1));
+const webComponentBuilds = [];
+
+if (!componentArg || componentArg === 'merch-card-collection') {
+    webComponentBuilds.push(
+        build({
+            ...defaults,
+            stdin: { contents: '' },
+            inject: ['./src/merch-offer.js', './src/merch-offer-select.js'],
+            plugins: [rewriteImportsToLibsFolder()],
+            outfile: `${outfolder}/merch-offer-select.js`,
+        }),
+        build({
+            ...defaults,
+            entryPoints: ['./src/merch-card-collection.js'],
+            plugins: [rewriteImportsToLibsFolder()],
+            outfile: `${outfolder}/merch-card-collection.js`,
+        }),
+    );
+}
+
+if (!componentArg) {
+    webComponentBuilds.push(
+        build({
+            ...defaults,
+            entryPoints: ['./src/sidenav/merch-sidenav.js'],
+            outfile: `${outfolder}/merch-sidenav.js`,
+            plugins: [rewriteImportsToLibsFolder()],
+        }),
+        build({
+            ...defaults,
+            entryPoints: ['./src/mas-field.js'],
+            outfile: `${outfolder}/mas-field.js`,
+        }),
+    );
+}
+
+if (!componentArg || componentArg === 'merch-card') {
+    webComponentBuilds.push(
+        buildLitComponent('merch-card'),
+    );
+}
+
+if (!componentArg) {
+    webComponentBuilds.push(
+        buildLitComponent('merch-icon'),
+        buildLitComponent('merch-quantity-select'),
+        buildLitComponent('merch-secure-transaction'),
+        buildLitComponent('merch-stock'),
+        buildLitComponent('merch-whats-included'),
+        buildLitComponent('merch-mnemonic-list'),
+        buildLitComponent('mas-mnemonic'),
+    );
+}
+
+Promise.all(webComponentBuilds).catch(() => process.exit(1));
 
 async function buildLitComponent(name) {
     const { metafile } = await build({

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -10,6 +10,8 @@
         "build:dev": "npm run build:bundle sourcemap no-minify",
         "build:docs": "./docs/src/build-docs.sh",
         "build:bundle": "node ./build.mjs",
+        "build:merch-card": "node ./build.mjs merch-card",
+        "build:merch-card-collection": "node ./build.mjs merch-card-collection",
         "build:bundle:dev": "npm run build:bundle sourcemap",
         "watch": "node ./watch.mjs",
         "dev": "node ./watch.mjs --serve",


### PR DESCRIPTION
## Summary
- Decouple `merch-card-collection` CI builds from `merch-card` by splitting the single `build-and-test` job into per-component jobs with path-specific triggers
- Add selective component builds to `build.mjs` so each CI job only builds the component it needs
- Add `build:merch-card` and `build:merch-card-collection` npm scripts

Closes #112

---
## 🪅 ADW Implementation

**Spec:** [📦 View implementation spec](https://github.com/adobe-pinata/mas/blob/chore-112-remove-merch-card-dep-from-collection/.pinata/specs/issue-112-adw-d39975f0-sdlc_planner-remove-merch-card-build-dep-from-collection.md)
**ADW ID:** `d39975f0`