### PR TITLE
feat: add pinata agent and code review workflows

### DIFF
--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -49,8 +49,9 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          EVENT_TYPE: ${{ github.event.inputs.event_type || github.event.action || 'workflow_dispatch' }}
+          SOURCE_REPO: ${{ github.repository }}
         run: |
           cd harness
-          PR_NUMBER=${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-          EVENT_TYPE=${{ github.event.inputs.event_type || (github.event_name == 'workflow_dispatch' && 'workflow_dispatch') || github.event.action }}
-          claude --settings '{"hooks":{"SessionStart":[],"PreToolUse":[],"PostToolUse":[],"Notification":[],"Stop":[],"SubagentStop":[],"PreCompact":[],"UserPromptSubmit":[],"SessionEnd":[]}}' -p "/app:pinata:review ${{ github.repository }} ${PR_NUMBER} ${EVENT_TYPE}"
+          claude --settings '{"hooks":{"SessionStart":[],"PreToolUse":[],"PostToolUse":[],"Notification":[],"Stop":[],"SubagentStop":[],"PreCompact":[],"UserPromptSubmit":[],"SessionEnd":[]}}' -p "/app:pinata:review ${SOURCE_REPO} ${PR_NUMBER} ${EVENT_TYPE}"

--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -1,0 +1,56 @@
+name: "Piñata Code Review"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+      event_type:
+        description: "Event type override (workflow_dispatch|opened|synchronize|ready_for_review|reopened)"
+        required: false
+        default: "workflow_dispatch"
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  pinata-review:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PINATA_APP_ID }}
+          private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Checkout agentic-harness
+        uses: actions/checkout@v4
+        with:
+          repository: joaquinrivero/agentic-harness
+          token: ${{ steps.app-token.outputs.token }}
+          path: harness
+
+      - name: Run Piñata Code Review
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          cd harness
+          PR_NUMBER=${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          EVENT_TYPE=${{ github.event.inputs.event_type || (github.event_name == 'workflow_dispatch' && 'workflow_dispatch') || github.event.action }}
+          claude --settings '{"hooks":{"SessionStart":[],"PreToolUse":[],"PostToolUse":[],"Notification":[],"Stop":[],"SubagentStop":[],"PreCompact":[],"UserPromptSubmit":[],"SessionEnd":[]}}' -p "/app:pinata:review ${{ github.repository }} ${PR_NUMBER} ${EVENT_TYPE}"

--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -13,9 +13,14 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pinata-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     permissions:
       contents: read
@@ -41,6 +46,7 @@ jobs:
         with:
           app-id: ${{ secrets.PINATA_APP_ID }}
           private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+          # NOTE: harness repo is currently under a personal account — update if it moves to the org
           repositories: agentic-harness
           owner: joaquinrivero
 

--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -35,6 +35,15 @@ jobs:
           app-id: ${{ secrets.PINATA_APP_ID }}
           private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
 
+      - name: Generate harness repo token
+        id: harness-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PINATA_APP_ID }}
+          private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+          repositories: agentic-harness
+          owner: joaquinrivero
+
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
@@ -42,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: joaquinrivero/agentic-harness
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.harness-token.outputs.token }}
           path: harness
 
       - name: Run Piñata Code Review

--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -29,20 +29,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.PINATA_APP_ID }}
           private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
 
       - name: Generate harness repo token
         id: harness-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.PINATA_APP_ID }}
           private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
@@ -54,11 +54,24 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Checkout agentic-harness
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: joaquinrivero/agentic-harness
           token: ${{ steps.harness-token.outputs.token }}
           path: harness
+
+      - name: Validate inputs
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          EVENT_TYPE: ${{ github.event.inputs.event_type || github.event.action || 'workflow_dispatch' }}
+        run: |
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number: ${PR_NUMBER}" && exit 1
+          fi
+          valid_events="workflow_dispatch opened synchronize ready_for_review reopened"
+          if ! echo "$valid_events" | grep -qw "$EVENT_TYPE"; then
+            echo "::error::Invalid event type: ${EVENT_TYPE}" && exit 1
+          fi
 
       - name: Run Piñata Code Review
         env:
@@ -69,4 +82,4 @@ jobs:
           SOURCE_REPO: ${{ github.repository }}
         run: |
           cd harness
-          claude --settings '{"hooks":{"SessionStart":[],"PreToolUse":[],"PostToolUse":[],"Notification":[],"Stop":[],"SubagentStop":[],"PreCompact":[],"UserPromptSubmit":[],"SessionEnd":[]}}' -p "/app:pinata:review ${SOURCE_REPO} ${PR_NUMBER} ${EVENT_TYPE}"
+          claude --settings '{"hooks":{"SessionStart":[],"PreToolUse":[],"PostToolUse":[],"Notification":[],"Stop":[],"SubagentStop":[],"PreCompact":[],"UserPromptSubmit":[],"SessionEnd":[]}}' -p "/app:pinata:review \"${SOURCE_REPO}\" \"${PR_NUMBER}\" \"${EVENT_TYPE}\""

--- a/.github/workflows/pinata.yml
+++ b/.github/workflows/pinata.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@pinata-agent')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@pinata-agent') || contains(github.event.issue.title, '@pinata-agent')))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -54,9 +55,10 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
         run: |
-          echo "body<<BODY_DELIM" >> "$GITHUB_OUTPUT"
+          DELIM="EOF_$(openssl rand -hex 8)"
+          echo "body<<${DELIM}" >> "$GITHUB_OUTPUT"
           echo "$COMMENT_BODY" >> "$GITHUB_OUTPUT"
-          echo "BODY_DELIM" >> "$GITHUB_OUTPUT"
+          echo "${DELIM}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve issue/PR number
         if: always()
@@ -78,6 +80,7 @@ jobs:
         with:
           app-id: ${{ secrets.PINATA_APP_ID }}
           private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+          # NOTE: harness repo is currently under a personal account — update if it moves to the org
           repositories: agentic-harness
           owner: joaquinrivero
 

--- a/.github/workflows/pinata.yml
+++ b/.github/workflows/pinata.yml
@@ -49,45 +49,30 @@ jobs:
             actions: read
 
       - name: Resolve comment body
+        if: always()
         id: comment-body
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
         run: |
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            BODY=$(cat <<'BODY_EOF'
-          ${{ github.event.comment.body }}
-          BODY_EOF
-            )
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            BODY=$(cat <<'BODY_EOF'
-          ${{ github.event.comment.body }}
-          BODY_EOF
-            )
-          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            BODY=$(cat <<'BODY_EOF'
-          ${{ github.event.review.body }}
-          BODY_EOF
-            )
-          elif [ "${{ github.event_name }}" = "issues" ]; then
-            BODY=$(cat <<'BODY_EOF'
-          ${{ github.event.issue.body }}
-          BODY_EOF
-            )
-          fi
           echo "body<<BODY_DELIM" >> "$GITHUB_OUTPUT"
-          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "$COMMENT_BODY" >> "$GITHUB_OUTPUT"
           echo "BODY_DELIM" >> "$GITHUB_OUTPUT"
 
       - name: Resolve issue/PR number
+        if: always()
         id: number
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -n "${{ github.event.issue.number }}" ]; then
-            echo "value=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ github.event.pull_request.number }}" ]; then
-            echo "value=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${{ github.event.comment.id }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "value=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          elif [ -n "$PR_NUMBER" ]; then
+            echo "value=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate harness repo token
+        if: always()
         id: harness-token
         uses: actions/create-github-app-token@v1
         with:
@@ -97,6 +82,7 @@ jobs:
           owner: joaquinrivero
 
       - name: Dispatch to harness knowledge-bot
+        if: always()
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.harness-token.outputs.token }}

--- a/.github/workflows/pinata.yml
+++ b/.github/workflows/pinata.yml
@@ -1,0 +1,113 @@
+name: "Piñata Agent"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  pinata-agent:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@pinata-agent')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@pinata-agent')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@pinata-agent')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@pinata-agent') || contains(github.event.issue.title, '@pinata-agent')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PINATA_APP_ID }}
+          private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+
+      - name: Run Piñata Agent
+        id: pinata
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          trigger_phrase: "@pinata-agent"
+          bot_name: "Piñata"
+          additional_permissions: |
+            actions: read
+
+      - name: Resolve comment body
+        id: comment-body
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            BODY=$(cat <<'BODY_EOF'
+          ${{ github.event.comment.body }}
+          BODY_EOF
+            )
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            BODY=$(cat <<'BODY_EOF'
+          ${{ github.event.comment.body }}
+          BODY_EOF
+            )
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            BODY=$(cat <<'BODY_EOF'
+          ${{ github.event.review.body }}
+          BODY_EOF
+            )
+          elif [ "${{ github.event_name }}" = "issues" ]; then
+            BODY=$(cat <<'BODY_EOF'
+          ${{ github.event.issue.body }}
+          BODY_EOF
+            )
+          fi
+          echo "body<<BODY_DELIM" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "BODY_DELIM" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve issue/PR number
+        id: number
+        run: |
+          if [ -n "${{ github.event.issue.number }}" ]; then
+            echo "value=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.pull_request.number }}" ]; then
+            echo "value=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.event.comment.id }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate harness repo token
+        id: harness-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PINATA_APP_ID }}
+          private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+          repositories: agentic-harness
+          owner: joaquinrivero
+
+      - name: Dispatch to harness knowledge-bot
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.harness-token.outputs.token }}
+          repository: joaquinrivero/agentic-harness
+          event-type: pinata-knowledge-bot
+          client-payload: |
+            {
+              "source_repo": "${{ github.repository }}",
+              "source_repo_owner": "${{ github.repository_owner }}",
+              "source_repo_name": "${{ github.event.repository.name }}",
+              "event_type": "${{ github.event_name }}",
+              "number": "${{ steps.number.outputs.value }}",
+              "comment_body": ${{ toJSON(steps.comment-body.outputs.body) }}
+            }

--- a/.github/workflows/pinata.yml
+++ b/.github/workflows/pinata.yml
@@ -27,20 +27,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.PINATA_APP_ID }}
           private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
 
       - name: Run Piñata Agent
         id: pinata
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -50,7 +50,7 @@ jobs:
             actions: read
 
       - name: Resolve comment body
-        if: always()
+        if: ${{ !cancelled() }}
         id: comment-body
         env:
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
@@ -61,7 +61,7 @@ jobs:
           echo "${DELIM}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve issue/PR number
-        if: always()
+        if: ${{ !cancelled() }}
         id: number
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -74,9 +74,9 @@ jobs:
           fi
 
       - name: Generate harness repo token
-        if: always()
+        if: ${{ !cancelled() }}
         id: harness-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.PINATA_APP_ID }}
           private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
@@ -85,8 +85,8 @@ jobs:
           owner: joaquinrivero
 
       - name: Dispatch to harness knowledge-bot
-        if: always()
-        uses: peter-evans/repository-dispatch@v3
+        if: ${{ !cancelled() }}
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ steps.harness-token.outputs.token }}
           repository: joaquinrivero/agentic-harness


### PR DESCRIPTION
## Summary
- Adds `pinata.yml` — handles @pinata-agent mentions locally and dispatches to harness knowledge-bot for domain expertise
- Adds `pinata-code-review.yml` — automatic PR code review using harness mental models and skills

## Prerequisites
The following secrets must be configured in repo settings:
- `PINATA_APP_ID`
- `PINATA_APP_PRIVATE_KEY`
- `CLAUDE_CODE_OAUTH_TOKEN`

## Test plan
- [ ] Verify secrets are configured in adobe-pinata/mas repo settings
- [ ] Open a test PR and confirm pinata-code-review triggers
- [ ] Comment @pinata-agent on an issue and confirm local response + harness dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)