### PR TITLE
ci: redirect Nala to adobecom and soften fork PR catalog load

### DIFF
--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -28,10 +28,11 @@ jobs:
     run-nala-studio-tests:
         name: Running Nala Studio E2E UI Tests
         needs: nala-gate
-        # Run when PR is opened (no label needed) OR when 'run nala' label exists
-        # This covers: opened (always), synchronize (if label exists), labeled (if label exists)
+        # Auto-run on PR open ONLY for upstream adobecom/mas PRs.
+        # Fork PRs (e.g. adobe-pinata/mas) must explicitly opt in via the
+        # 'run nala' label to reduce shared MAS IO catalog load.
         if: |
-            github.event.action == 'opened' ||
+            (github.event.action == 'opened' && github.event.pull_request.head.repo.full_name == 'adobecom/mas') ||
             contains(github.event.pull_request.labels.*.name, 'run nala')
         runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30 # Prevent hanging jobs
@@ -109,10 +110,11 @@ jobs:
     run-nala-docs-tests:
         name: Running Nala Docs E2E UI Tests
         needs: nala-gate
-        # Run when PR is opened (no label needed) OR when 'run nala' label exists
-        # This covers: opened (always), synchronize (if label exists), labeled (if label exists)
+        # Auto-run on PR open ONLY for upstream adobecom/mas PRs.
+        # Fork PRs (e.g. adobe-pinata/mas) must explicitly opt in via the
+        # 'run nala' label to reduce shared MAS IO catalog load.
         if: |
-            github.event.action == 'opened' ||
+            (github.event.action == 'opened' && github.event.pull_request.head.repo.full_name == 'adobecom/mas') ||
             contains(github.event.pull_request.labels.*.name, 'run nala')
         runs-on: ubuntu-latest
         timeout-minutes: 20 # Prevent hanging jobs

--- a/nala/utils/gh.run.sh
+++ b/nala/utils/gh.run.sh
@@ -33,6 +33,18 @@ toRepoName=${repoParts[1]}
 prRepo=${prRepo:-$toRepoName}
 prOrg=${prOrg:-$toRepoOrg}
 
+# Nala preview on forks:
+# When running on the adobe-pinata/mas fork, AEM Edge Delivery does not build
+# adobe-pinata.aem.live previews, and IMS does not whitelist that host as a
+# redirect URI. Redirect Nala to the corresponding branch preview on
+# adobecom/mas so authentication and the preview URL resolve correctly.
+# The branch must exist on adobecom/mas for this to work.
+if [[ "$prOrg" == "adobe-pinata" ]]; then
+  echo "Fork detected (adobe-pinata) - redirecting Nala preview to adobecom/mas"
+  prOrg="adobecom"
+  prRepo="mas"
+fi
+
 PR_BRANCH_LIVE_URL_GH="https://$FEATURE_BRANCH--$prRepo--$prOrg.aem.live"
 
 # set pr branch url as env

--- a/nala/utils/gh.run.sh
+++ b/nala/utils/gh.run.sh
@@ -43,6 +43,10 @@ if [[ "$prOrg" == "adobe-pinata" ]]; then
   echo "Fork detected (adobe-pinata) - redirecting Nala preview to adobecom/mas"
   prOrg="adobecom"
   prRepo="mas"
+  # Soften shared MAS IO catalog load on fork PRs: no retries, fewer workers.
+  # Upstream adobecom/mas runs are unaffected.
+  export PWTEST_RETRIES=0
+  export PLAYWRIGHT_WORKERS=2
 fi
 
 PR_BRANCH_LIVE_URL_GH="https://$FEATURE_BRANCH--$prRepo--$prOrg.aem.live"

--- a/nala/utils/global.teardown.js
+++ b/nala/utils/global.teardown.js
@@ -158,14 +158,20 @@ async function cleanupClonedCards() {
         const baseURL =
             process.env.PR_BRANCH_LIVE_URL || process.env.LOCAL_TEST_LIVE_URL || 'https://main--mas--adobecom.aem.live';
 
-        // Define paths to check for fragments (different locales/views)
-        const pathsToCheck = [
-            '#page=content&path=nala', // Default path
-            '#locale=fr_FR&page=content&path=nala', // French locale path
-            '#locale=en_CA&page=content&path=nala', // Canadian locale path
-            '#locale=en_GB&page=content&path=nala', // British locale path
-            '#locale=en_AU&page=content&path=nala', // Australian locale path
-        ];
+        // Define paths to check for fragments (different locales/views).
+        // On fork PRs (adobe-pinata/mas), only check fr_FR (the canonical
+        // nala test fragment locale per .claude/rules/testing-nala.md) to
+        // reduce shared MAS IO catalog load. Upstream runs check all 5.
+        const isForkRun = process.env.GITHUB_REPOSITORY === 'adobe-pinata/mas';
+        const pathsToCheck = isForkRun
+            ? ['#locale=fr_FR&page=content&path=nala']
+            : [
+                  '#page=content&path=nala',
+                  '#locale=fr_FR&page=content&path=nala',
+                  '#locale=en_CA&page=content&path=nala',
+                  '#locale=en_GB&page=content&path=nala',
+                  '#locale=en_AU&page=content&path=nala',
+              ];
 
         let totalFragmentsFound = 0;
         let totalFragmentsDeleted = 0;

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -29,7 +29,7 @@ const config = {
     /* Retry on CI only */
     retries: process.env.CI ? 1 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 4 : 3,
+    workers: process.env.PLAYWRIGHT_WORKERS ? Number(process.env.PLAYWRIGHT_WORKERS) : process.env.CI ? 4 : 3,
     /* Reporter to use. */
     reporter: process.env.CI
         ? [['github'], ['list'], ['./nala/utils/base-reporter.js']]


### PR DESCRIPTION
## Summary

Two related CI infrastructure changes for `adobe-pinata/mas` Nala runs, bundled in one PR. Both fire only when the PR head is the `adobe-pinata` fork — upstream `adobecom/mas` Nala behavior is provably unchanged.

### Commit 1 — Redirect Nala preview to adobecom on fork PRs

`adobe-pinata.aem.live` previews are not built by AEM Edge Delivery, and the `mas-studio` IMS client does not whitelist that host as a redirect URI. Result: every fork PR `auth.setup.cjs` run fails with a 45s `waitForURL` timeout because IMS falls back to `www.adobe.com/mas/studio.html` after login, never returning to the fork preview.

`nala/utils/gh.run.sh` now detects `prOrg == "adobe-pinata"` and rewrites `prOrg`/`prRepo` to `adobecom`/`mas` so Nala targets the whitelisted, actually-built preview host. The branch under test must exist on `adobecom/mas` for the redirected URL to serve content.

### Commit 2 — Soften shared MAS IO catalog load on fork PRs

A teammate flagged 5xx spikes on `mats-mas-io` `.catalog` via Grafana and asked whether pinata fork tests can be softened. Now that fork PRs share the same backend as upstream PRs (commit 1), every fork-side amplifier (4 workers, 1 retry, 5-locale teardown, auto-run on PR open) duplicates load that upstream PRs already pay at merge time.

Four conservative cuts, all gated on the fork:

1. **`gh.run.sh`** — inside the existing fork-detection block, export `PWTEST_RETRIES=0` (no retry-amplification of flaky catalog tests) and `PLAYWRIGHT_WORKERS=2` (halve concurrent catalog bursts).

2. **`playwright.config.js`** — honor `PLAYWRIGHT_WORKERS` env var. Backward compatible: every existing caller leaves it unset and gets the prior `CI=4 / local=3` default.

3. **`global.teardown.js`** — when `GITHUB_REPOSITORY=adobe-pinata/mas`, check only the `fr_FR` locale path (the canonical nala test fragment locale per `.claude/rules/testing-nala.md`) instead of all 5. Cuts teardown catalog calls by ~80% on fork PRs and removes ~360s of worst-case timeout. Upstream still checks all 5 paths.

4. **`run-nala.yml`** — tighten the auto-run-on-`opened` gate to require `head.repo.full_name == 'adobecom/mas'`. Fork PRs must explicitly add the `run nala` label, same as the existing `synchronize` gate. Both `run-nala-studio-tests` and `run-nala-docs-tests` updated identically.

## Why no Jira ticket

This PR responds to a direct Slack ask about a Grafana 5xx alert, not a tracked feature. The branch is `ci/soften-fork-nala-load` (intentionally no `MWPW-XXXXX`).

## Why both commits in one PR

The softening (commit 2) reuses the fork-detection `if` block added by commit 1, so they share the same code surface in `gh.run.sh`. Splitting would mean rebasing commit 2 after commit 1 lands. Bundling here for review locality.

## Files changed

| File | What | Lines |
|---|---|---|
| `nala/utils/gh.run.sh` | + fork-detection block + soften exports | +16 |
| `playwright.config.js` | honor `PLAYWRIGHT_WORKERS` env var | 1 changed |
| `nala/utils/global.teardown.js` | filter `pathsToCheck` on fork runs | +14 / −8 |
| `.github/workflows/run-nala.yml` | tighten `if:` gate on both jobs | 14 changed |

**Total: 4 files, ~39 lines net.** No test files modified, no page objects touched, no new tags introduced.

## Test plan

Local validation already done:

- [x] `bash -n nala/utils/gh.run.sh` — syntax OK
- [x] Sourced `gh.run.sh` under simulated fork env (`prOrg=adobe-pinata`) — confirmed exports fire: `PWTEST_RETRIES=0`, `PLAYWRIGHT_WORKERS=2`, `prOrg=adobecom`, `prRepo=mas`
- [x] `playwright.config.js` workers in 4 env permutations:
  - default → 3 (local)
  - `PLAYWRIGHT_WORKERS=2` → 2
  - `CI=1` → 4 (upstream CI default unchanged)
  - `CI=1 PLAYWRIGHT_WORKERS=2` → 2 (fork CI override)
- [x] `global.teardown.js` `pathsToCheck` in 3 env permutations:
  - `GITHUB_REPOSITORY=adobe-pinata/mas` → 1 path (`fr_FR` only)
  - `GITHUB_REPOSITORY=adobecom/mas` → 5 paths (all locales)
  - unset (local) → 5 paths
- [x] `npx eslint` on modified JS files — clean
- [x] `python3 yaml.safe_load` on modified workflow — parses

Pending CI/PR-time validation:

- [ ] After merge, open a no-op PR on `adobe-pinata/mas` and confirm `Run Nala Tests` does **not** auto-trigger on `opened`
- [ ] Add `run nala` label, confirm both jobs trigger
- [ ] In the run log: see `"Fork detected (adobe-pinata)"`, `"Running N tests using 2 workers"`, no `(retry #1)` lines, exactly one `📍 Checking path: #locale=fr_FR...` in teardown
- [ ] Compare Grafana `mats-mas-io` `.catalog` request rate during the run window to a pre-change baseline; capture before/after for the alerter
- [ ] Open a no-op PR on **upstream** `adobecom/mas` and confirm: studio job auto-triggers on `opened`, summary shows 4 workers, teardown shows 5 paths — proves upstream behavior is untouched

## Risks

| Risk | Mitigation |
|---|---|
| Retries=0 makes flaky fork PRs look red | Acceptable: a flake on fork is also a flake on upstream and should be visible. Author re-triggers via label. |
| Teardown only cleans `fr_FR` on fork — non-fr_FR test fragments could leak | Per `.claude/rules/testing-nala.md`, all nala test fragments must be in `fr_FR`. Tests creating non-fr_FR fragments already violate that rule. Upstream still checks all 5 paths as a safety net. |
| `if:` expression typo could regress upstream auto-trigger | Verification step above explicitly tests this on a no-op upstream PR before considering this merged. |

## Out of scope

- `studio-monitor.yml` (every-15-min cron) — already gated to `fork == false`, doesn't run on fork.
- `run-nala-daily.yml` — same, already fork-gated.
- Any upstream `adobecom/mas` Nala tuning — that's a separate conversation with @npeltier if the alerter wants more.