### PR TITLE
chore: add .pinata.config.json for adobecom/mas-pinata

### DIFF
--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -46,18 +46,17 @@ jobs:
               with:
                   app-id: ${{ secrets.PINATA_APP_ID }}
                   private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
-                  # NOTE: harness repo is currently under a personal account — update if it moves to the org
-                  repositories: agentic-harness
-                  owner: joaquinrivero
+                  repositories: pinata
+                  owner: adobe-pinata
 
             - name: Install Claude Code
               # TODO: unpin once upstream fix lands (2.1.88 broke skill resolution in -p mode)
               run: npm install -g @anthropic-ai/claude-code@2.1.87
 
-            - name: Checkout agentic-harness
+            - name: Checkout harness
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
-                  repository: joaquinrivero/agentic-harness
+                  repository: adobe-pinata/pinata
                   token: ${{ steps.harness-token.outputs.token }}
                   path: harness
 

--- a/.github/workflows/pinata.yml
+++ b/.github/workflows/pinata.yml
@@ -80,16 +80,15 @@ jobs:
               with:
                   app-id: ${{ secrets.PINATA_APP_ID }}
                   private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
-                  # NOTE: harness repo is currently under a personal account — update if it moves to the org
-                  repositories: agentic-harness
-                  owner: joaquinrivero
+                  repositories: pinata
+                  owner: adobe-pinata
 
             - name: Dispatch to harness knowledge-bot
               if: ${{ !cancelled() }}
               uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.harness-token.outputs.token }}
-                  repository: joaquinrivero/agentic-harness
+                  repository: adobe-pinata/pinata
                   event-type: pinata-knowledge-bot
                   client-payload: |
                       {

--- a/.pinata.config.json
+++ b/.pinata.config.json
@@ -1,24 +1,24 @@
 {
-  "source_app": "mas",
-  "name": "mas",
-  "app_name": "mas",
-  "github_repo": "adobecom/mas-pinata",
-  "github_app_installation_id": "118879229",
-  "default_branch": "main",
-  "branch_naming": "jira",
-  "r2_bucket": "pinata-mas",
-  "artifacts": {
-    "specs": "r2",
-    "docs": "r2",
-    "kpis": "harness"
-  },
-  "services": [
-    { "name": "aem",    "env_var": "AEM_PORT",    "default": 3000 },
-    { "name": "studio", "env_var": "STUDIO_PORT",  "default": 3100 },
-    { "name": "wc",     "env_var": "WC_PORT",      "default": 3200 }
-  ],
-  "libs_service": "aem",
-  "libs_param": "maslibs",
-  "libs_param_value": "local",
-  "depends_on": []
+    "source_app": "mas",
+    "name": "mas",
+    "app_name": "mas",
+    "github_repo": "adobecom/mas-pinata",
+    "github_app_installation_id": "118879229",
+    "default_branch": "main",
+    "branch_naming": "jira",
+    "r2_bucket": "pinata-mas",
+    "artifacts": {
+        "specs": "r2",
+        "docs": "r2",
+        "kpis": "harness"
+    },
+    "services": [
+        { "name": "aem", "env_var": "AEM_PORT", "default": 3000 },
+        { "name": "studio", "env_var": "STUDIO_PORT", "default": 3100 },
+        { "name": "wc", "env_var": "WC_PORT", "default": 3200 }
+    ],
+    "libs_service": "aem",
+    "libs_param": "maslibs",
+    "libs_param_value": "local",
+    "depends_on": []
 }

--- a/.pinata.config.json
+++ b/.pinata.config.json
@@ -1,0 +1,24 @@
+{
+  "source_app": "mas",
+  "name": "mas",
+  "app_name": "mas",
+  "github_repo": "adobecom/mas-pinata",
+  "github_app_installation_id": "118879229",
+  "default_branch": "main",
+  "branch_naming": "jira",
+  "r2_bucket": "pinata-mas",
+  "artifacts": {
+    "specs": "r2",
+    "docs": "r2",
+    "kpis": "harness"
+  },
+  "services": [
+    { "name": "aem",    "env_var": "AEM_PORT",    "default": 3000 },
+    { "name": "studio", "env_var": "STUDIO_PORT",  "default": 3100 },
+    { "name": "wc",     "env_var": "WC_PORT",      "default": 3200 }
+  ],
+  "libs_service": "aem",
+  "libs_param": "maslibs",
+  "libs_param_value": "local",
+  "depends_on": []
+}


### PR DESCRIPTION
## Summary
- Adds `.pinata.config.json` to the repo root, pointing `github_repo` to `adobecom/mas-pinata`
- Enables Pinata agent workflows (PR review, domain resolution, artifact routing) for this repo

## Context
MAS fork is migrating from `adobe-pinata/mas` to `adobecom/mas-pinata`. This config file is required by the agentic harness to identify and route workflows for this app.

Companion PR: https://github.com/joaquinrivero/agentic-harness/pull/153

## Test plan
- [ ] Verify Pinata review triggers on a test PR in this repo
- [ ] Confirm domain resolution maps to the expected MAS mental model domains