### PR TITLE
chore: identify Playwright UA as AI-POD-MAS-NALA

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
 import { devices } from '@playwright/test';
 
 const USER_AGENT_DESKTOP =
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.6900.0 Safari/537.36 NALA-MAS';
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.6900.0 Safari/537.36 AI-POD-MAS-NALA';
 
 /**
  * @see https://playwright.dev/docs/test-configuration


### PR DESCRIPTION
## Summary
- Replaces the generic `NALA-MAS` User-Agent suffix with `AI-POD-MAS-NALA` in `playwright.config.js`
- The `USER_AGENT_DESKTOP` constant is the single source of truth consumed by all five Playwright projects, so this single-line change covers them all
- Suggested by Milica to make automated test traffic from this repo more identifiable server-side

## Test plan
- [ ] Verify `grep -rn "NALA-MAS" playwright.config.js` returns no matches
- [ ] Spot-check one Nala test run and confirm the network request UA ends with `AI-POD-MAS-NALA`