### PR TITLE
chore: rename Playwright UA suffix to MAS-PINATA-NALA

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
 import { devices } from '@playwright/test';
 
 const USER_AGENT_DESKTOP =
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.6900.0 Safari/537.36 AI-POD-MAS-NALA';
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.6900.0 Safari/537.36 MAS-PINATA-NALA';
 
 /**
  * @see https://playwright.dev/docs/test-configuration


### PR DESCRIPTION
## Summary
- Renames the Playwright User-Agent suffix from `AI-POD-MAS-NALA` to `MAS-PINATA-NALA`
- Reflects the source repository name rather than the team identifier, making test traffic attribution more precise
- `USER_AGENT_DESKTOP` is the single source of truth consumed by all Playwright projects in the config

## Test plan
- [ ] Verify `grep -rn "AI-POD-MAS-NALA" playwright.config.js` returns no matches
- [ ] Spot-check one Nala test run and confirm the network request UA ends with `MAS-PINATA-NALA`