### PR TITLE
chore: fix pinata workflows — update harness org from adobe-pinata to adobe-acom

### DIFF
--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -47,7 +47,7 @@ jobs:
                   app-id: ${{ secrets.PINATA_APP_ID }}
                   private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
                   repositories: pinata
-                  owner: adobe-pinata
+                  owner: adobe-acom
 
             - name: Install Claude Code
               # TODO: unpin once upstream fix lands (2.1.88 broke skill resolution in -p mode)
@@ -56,7 +56,7 @@ jobs:
             - name: Checkout harness
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
-                  repository: adobe-pinata/pinata
+                  repository: adobe-acom/pinata
                   token: ${{ steps.harness-token.outputs.token }}
                   path: harness
 

--- a/.github/workflows/pinata.yml
+++ b/.github/workflows/pinata.yml
@@ -81,14 +81,14 @@ jobs:
                   app-id: ${{ secrets.PINATA_APP_ID }}
                   private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
                   repositories: pinata
-                  owner: adobe-pinata
+                  owner: adobe-acom
 
             - name: Dispatch to harness knowledge-bot
               if: ${{ !cancelled() }}
               uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.harness-token.outputs.token }}
-                  repository: adobe-pinata/pinata
+                  repository: adobe-acom/pinata
                   event-type: pinata-knowledge-bot
                   client-payload: |
                       {

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 **/logs/
+.pinata/docs/
+.pinata/logs/
+.pinata/specs/
+.pinata/state/
 helix-importer-ui
 .DS_Store
 *.bak

--- a/.pinata/.config.json
+++ b/.pinata/.config.json
@@ -24,15 +24,15 @@
     "depends_on": [],
     "test_urls": {
         "envs": {
-            "@mas_live":        "https://main--mas-pinata--adobecom.aem.live",
-            "@mas_preview":     "https://main--mas-pinata--adobecom.aem.page",
+            "@mas_live": "https://main--mas-pinata--adobecom.aem.live",
+            "@mas_preview": "https://main--mas-pinata--adobecom.aem.page",
             "@mas_studio_live": "https://main--mas-pinata--adobecom.aem.live/studio.html",
-            "@milo_live":       "https://main--milo--adobecom.aem.live",
-            "@cc_live":         "https://main--cc--adobecom.aem.live",
-            "@adobe_prod":      "https://www.adobe.com",
-            "@adobe_stage":     "https://www.stage.adobe.com"
+            "@milo_live": "https://main--milo--adobecom.aem.live",
+            "@cc_live": "https://main--cc--adobecom.aem.live",
+            "@adobe_prod": "https://www.adobe.com",
+            "@adobe_stage": "https://www.stage.adobe.com"
         },
-        "libs_param":   "maslibs",
+        "libs_param": "maslibs",
         "default_path": "/"
     }
 }


### PR DESCRIPTION
## What

Correct the GitHub org reference for the pinata harness in both workflow files.

| | Before | After |
|---|---|---|
| `harness-token` owner | `adobe-pinata` | `adobe-acom` |
| `repository-dispatch` target | `adobe-pinata/pinata` | `adobe-acom/pinata` |
| `checkout harness` repository | `adobe-pinata/pinata` | `adobe-acom/pinata` |

## Why

The pinata harness lives at `adobe-acom/pinata`, where the GitHub App is installed. The previous org (`adobe-pinata`) was wrong — the `harness-token` step would fail to generate a valid cross-org installation token, causing both the knowledge-bot dispatch (`pinata.yml`) and the harness checkout (`pinata-code-review.yml`) to fail at runtime.

## Token model (unchanged)

Two tokens are intentionally kept separate because `adobecom` and `adobe-acom` are different GitHub orgs — each requires its own installation token:

- **`app-token`** — scoped to `adobecom`: agent `github_token` + PR-level `GH_TOKEN`
- **`harness-token`** — scoped to `adobe-acom/pinata`: cross-org dispatch + harness checkout

## Files changed

- `.github/workflows/pinata.yml` — `owner` + `repository` in `harness-token` and `Dispatch to harness knowledge-bot` steps
- `.github/workflows/pinata-code-review.yml` — `owner` + `repository` in `harness-token` and `Checkout harness` steps

URL for testing:

- https://chore-pinata-workflows-adobe-acom--mas-pinata--adobecom.aem.page/