### PR TITLE
chore: sync pinata workflows to adobe-acom harness

### DIFF
--- a/.github/workflows/pinata-code-review.yml
+++ b/.github/workflows/pinata-code-review.yml
@@ -47,7 +47,7 @@ jobs:
                   app-id: ${{ secrets.PINATA_APP_ID }}
                   private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
                   repositories: pinata
-                  owner: adobe-pinata
+                  owner: adobe-acom
 
             - name: Install Claude Code
               # TODO: unpin once upstream fix lands (2.1.88 broke skill resolution in -p mode)
@@ -56,7 +56,7 @@ jobs:
             - name: Checkout harness
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
-                  repository: adobe-pinata/pinata
+                  repository: adobe-acom/pinata
                   token: ${{ steps.harness-token.outputs.token }}
                   path: harness
 

--- a/.github/workflows/pinata.yml
+++ b/.github/workflows/pinata.yml
@@ -81,14 +81,14 @@ jobs:
                   app-id: ${{ secrets.PINATA_APP_ID }}
                   private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
                   repositories: pinata
-                  owner: adobe-pinata
+                  owner: adobe-acom
 
             - name: Dispatch to harness knowledge-bot
               if: ${{ !cancelled() }}
               uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.harness-token.outputs.token }}
-                  repository: adobe-pinata/pinata
+                  repository: adobe-acom/pinata
                   event-type: pinata-knowledge-bot
                   client-payload: |
                       {

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 **/logs/
+.pinata/docs/
+.pinata/logs/
+.pinata/specs/
+.pinata/state/
 helix-importer-ui
 .DS_Store
 *.bak

--- a/.pinata/.config.json
+++ b/.pinata/.config.json
@@ -24,15 +24,15 @@
     "depends_on": [],
     "test_urls": {
         "envs": {
-            "@mas_live":        "https://main--mas-pinata--adobecom.aem.live",
-            "@mas_preview":     "https://main--mas-pinata--adobecom.aem.page",
+            "@mas_live": "https://main--mas-pinata--adobecom.aem.live",
+            "@mas_preview": "https://main--mas-pinata--adobecom.aem.page",
             "@mas_studio_live": "https://main--mas-pinata--adobecom.aem.live/studio.html",
-            "@milo_live":       "https://main--milo--adobecom.aem.live",
-            "@cc_live":         "https://main--cc--adobecom.aem.live",
-            "@adobe_prod":      "https://www.adobe.com",
-            "@adobe_stage":     "https://www.stage.adobe.com"
+            "@milo_live": "https://main--milo--adobecom.aem.live",
+            "@cc_live": "https://main--cc--adobecom.aem.live",
+            "@adobe_prod": "https://www.adobe.com",
+            "@adobe_stage": "https://www.stage.adobe.com"
         },
-        "libs_param":   "maslibs",
+        "libs_param": "maslibs",
         "default_path": "/"
     }
 }


### PR DESCRIPTION
## Summary
- Switch harness references from `adobe-pinata/pinata` to `adobe-acom/pinata` in both Piñata workflows
- Add `.pinata/.config.json` repo config for harness app recognition
- Update `.gitignore` to exclude runtime `.pinata/` directories

URL for testing:

- https://mwpw-10345--mas-pinata--adobecom.aem.page/

## Test plan
- [ ] Verify "Piñata Code Review" workflow triggers and completes on PR
- [ ] Verify domain expertise routing works for `adobecom/mas-pinata`