### PR TITLE
Sync mas-pinata/main with adobecom/mas/main (2026-04-15)

### DIFF
--- a/.github/workflows/io-studio-deploy.yaml
+++ b/.github/workflows/io-studio-deploy.yaml
@@ -10,6 +10,13 @@ on:
                 type: number
                 required: false
                 default: 10
+            rps_limit:
+                type: number
+                required: false
+                default: 10
+                # NOTE: batch_size must not exceed rps_limit — each batch fires all requests
+                # simultaneously, so a batch larger than the RPS limit would burst past the
+                # limit before throttling applies.
         secrets:
             ENV:
                 required: true
@@ -75,4 +82,5 @@ jobs:
               env:
                   ODIN_ENDPOINT: 'https://author-p22655-${{ secrets.ODIN_BUCKET }}.adobeaemcloud.com'
                   BATCH_SIZE: ${{ inputs.batch_size }}
+                  RPS_LIMIT: ${{ inputs.rps_limit }}
               run: npx aio app deploy -v

--- a/.github/workflows/io-studio-merge.yaml
+++ b/.github/workflows/io-studio-merge.yaml
@@ -10,7 +10,8 @@ jobs:
         if: github.event.pull_request.merged == true
         uses: ./.github/workflows/io-studio-deploy.yaml
         with:
-            batch_size: 15
+            batch_size: 10
+            rps_limit: 20
         secrets:
             ENV: ${{ secrets.AIO_STUDIO_ENV_STAGE }}
             AIO: ${{  secrets.AIO_STUDIO_AIO_STAGE }}
@@ -26,7 +27,8 @@ jobs:
         needs: test_stage
         uses: ./.github/workflows/io-studio-deploy.yaml
         with:
-            batch_size: 25
+            batch_size: 10
+            rps_limit: 20
         secrets:
             ENV: ${{ secrets.AIO_STUDIO_ENV_PROD }}
             AIO: ${{  secrets.AIO_STUDIO_AIO_PROD }}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ export IMS_EMAIL=<val>
 export IMS_PASS=<val>
 ```
 
-Ask colleagues/slack for IMS_EMAIL ad IMS_PASS values, your user might not work as expected because it's not '@adobetest.com' account.
+Ask colleagues/slack for IMS_EMAIL and IMS_PASS values, your user might not work as expected because it's not '@adobetest.com' account.
 
 `npm run nala local` - to run on local
 `npm run nala MWPW-160756` - to run on branch

--- a/io/studio/app.config.yaml
+++ b/io/studio/app.config.yaml
@@ -63,6 +63,7 @@ application:
                         runtime: nodejs:22
                         inputs:
                             batchSize: $BATCH_SIZE
+                            rpsLimit: $RPS_LIMIT
                         limits:
                             timeout: 3600000
                         annotations:

--- a/io/studio/env_template
+++ b/io/studio/env_template
@@ -10,5 +10,9 @@ AIO_runtime_apihost=https://adobeioruntime.net
 ODIN_ENDPOINT=https://author-p22655-xxxx.adobeaemcloud.com
 
 # batch size of concurrent requests to send to odin loc v2 API ODIN_ENDPOINT (default: 10)
-BATCH_SIZE=15
+BATCH_SIZE=10
 
+# max sustained requests per second sent to odin (default: 10)
+# NOTE: batch_size must not exceed rps_limit — each batch fires all requests simultaneously,
+# so a batch larger than the RPS limit would burst past the limit before throttling applies.
+RPS_LIMIT=10

--- a/io/studio/src/common.js
+++ b/io/studio/src/common.js
@@ -347,16 +347,28 @@ async function patchToOdin(odinEndpoint, fragmentId, authToken, patchBody, etag)
     return { success: true };
 }
 
-// Helper function to process items in batches with concurrency limit
-async function processBatchWithConcurrency(items, batchSize, processor) {
+// Helper function to process items in batches with concurrency limit and optional RPS throttle.
+// rpsLimit enforces a minimum batch cycle time of (batchSize / rpsLimit) seconds so that the
+// sustained request rate never exceeds rpsLimit, regardless of individual request latency.
+// onBatchCompleted(batchResults) is called after each batch completes (before the throttle wait).
+async function processBatchWithConcurrency(items, batchSize, processor, rpsLimit = null, onBatchCompleted = null) {
     const allResults = [];
+    const minBatchMs = rpsLimit ? (batchSize / rpsLimit) * 1000 : 0;
 
     for (let i = 0; i < items.length; i += batchSize) {
+        const batchStart = Date.now();
         const batch = items.slice(i, i + batchSize);
         logger.info(`Processing batch ${Math.floor(i / batchSize) + 1} of ${Math.ceil(items.length / batchSize)}`);
 
         const batchResults = await Promise.all(batch.map(processor));
         allResults.push(...batchResults);
+
+        if (onBatchCompleted) await onBatchCompleted(batchResults);
+
+        if (minBatchMs > 0) {
+            const wait = minBatchMs - (Date.now() - batchStart);
+            if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait));
+        }
     }
 
     return allResults;

--- a/io/studio/src/translation/project-start-service.js
+++ b/io/studio/src/translation/project-start-service.js
@@ -17,6 +17,7 @@ const ODIN_PATH = (surface, locale, fragmentPath) => `/content/dam/mas/${surface
 const PATH_TOKENS = /\/content\/dam\/mas\/(?<surface>[\w-_]+)\/(?<parsedLocale>[\w-_]+)\/(?<fragmentPath>.+)/;
 const logger = Core.Logger('translation', { level: 'info' });
 const DEFAULT_BATCH_SIZE = 10;
+const DEFAULT_RPS_LIMIT = 10;
 
 async function prepareProjectStart(params, options = {}) {
     logger.info('Calling the main action');
@@ -48,6 +49,7 @@ async function prepareProjectStart(params, options = {}) {
         responseMessage,
         translationData,
         batchSize: Number(params.batchSize) || DEFAULT_BATCH_SIZE,
+        rpsLimit: Number(params.rpsLimit) || DEFAULT_RPS_LIMIT,
     };
 }
 
@@ -61,6 +63,7 @@ async function runPostVersioningStage(context) {
         context.authToken,
         context.batchSize,
         context.params,
+        context.rpsLimit,
     );
     if (!syncResult.success) {
         throw createProjectStartError(500, `Failed to sync: ${syncResult.error} target fragments`);
@@ -280,41 +283,37 @@ async function versionTargetFragment(fragmentToVersion, { authToken, title, para
 }
 
 async function versionTargetFragments(context, options = {}) {
-    const { translationData, authToken, batchSize, params } = context;
+    const { translationData, authToken, batchSize, rpsLimit, params } = context;
     const itemsToVersion = getVersioningTargets(translationData);
     const onBatchCompleted = options.onBatchCompleted;
     logger.info(`Versioning target items for ${itemsToVersion.length} items`);
-    const config = {
-        authToken,
-        title: translationData.title,
-        params,
-    };
+    const config = { authToken, title: translationData.title, params };
 
-    const results = [];
-    let completedItemCount = 0;
-    let failedItemCount = 0;
+    let runningCompleted = 0;
+    let runningFailed = 0;
 
-    for (let i = 0; i < itemsToVersion.length; i += batchSize) {
-        const batch = itemsToVersion.slice(i, i + batchSize);
-        logger.info(`Processing batch ${Math.floor(i / batchSize) + 1} of ${Math.ceil(itemsToVersion.length / batchSize)}`);
+    const results = await processBatchWithConcurrency(
+        itemsToVersion,
+        batchSize,
+        (item) => versionTargetFragment(item, config),
+        rpsLimit,
+        onBatchCompleted &&
+            (async (batchResults) => {
+                runningCompleted += batchResults.filter((r) => r.success).length;
+                runningFailed += batchResults.filter((r) => !r.success).length;
+                await onBatchCompleted({
+                    completedItemCount: runningCompleted,
+                    failedItemCount: runningFailed,
+                    itemCount: itemsToVersion.length,
+                });
+            }),
+    );
 
-        const batchResults = await Promise.all(batch.map((item) => versionTargetFragment(item, config)));
-        results.push(...batchResults);
-
-        completedItemCount += batchResults.filter((result) => result.success).length;
-        failedItemCount += batchResults.filter((result) => !result.success).length;
-
-        if (onBatchCompleted) {
-            await onBatchCompleted({
-                completedItemCount,
-                failedItemCount,
-                itemCount: itemsToVersion.length,
-            });
-        }
-    }
+    const failures = results.filter((result) => !result.success);
+    const completedItemCount = results.length - failures.length;
+    const failedItemCount = failures.length;
 
     if (failedItemCount > 0) {
-        const failures = results.filter((result) => !result.success);
         logger.error(`${failures.length} request(s) failed: ${failures.map((failure) => failure.item).join(', ')}`);
     }
 
@@ -411,9 +410,14 @@ async function sendSyncRequest({ path, update: { name, value } }, { authToken, p
     }
 }
 
-async function sendSyncRequests(itemsToSync, authToken, batchSize, params = {}) {
+async function sendSyncRequests(itemsToSync, authToken, batchSize, params = {}, rpsLimit = null) {
     const config = { authToken, params };
-    const results = await processBatchWithConcurrency(itemsToSync, batchSize, (item) => sendSyncRequest(item, config));
+    const results = await processBatchWithConcurrency(
+        itemsToSync,
+        batchSize,
+        (item) => sendSyncRequest(item, config),
+        rpsLimit,
+    );
 
     const failures = results.filter((result) => !result.success);
     if (failures.length > 0) {

--- a/io/studio/test/common.test.js
+++ b/io/studio/test/common.test.js
@@ -724,3 +724,108 @@ describe('common.js - fetchOdin', () => {
         });
     });
 });
+
+describe('common.js - processBatchWithConcurrency', () => {
+    let common;
+    let setTimeoutStub;
+
+    beforeEach(function () {
+        this.timeout(5000);
+
+        const mockLogger = {
+            info: sinon.stub(),
+            error: sinon.stub(),
+            warn: sinon.stub(),
+        };
+
+        setTimeoutStub = sinon.stub(global, 'setTimeout').callsFake((fn) => {
+            fn();
+            return 1;
+        });
+
+        common = proxyquire('../src/common.js', {
+            '@adobe/aio-sdk': {
+                Core: {
+                    Logger: sinon.stub().returns(mockLogger),
+                },
+            },
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should process all items across batches and return results in order', async () => {
+        const items = [10, 20, 30, 40, 50];
+        const processor = (item) => Promise.resolve(item * 2);
+
+        const results = await common.processBatchWithConcurrency(items, 2, processor);
+
+        expect(results).to.deep.equal([20, 40, 60, 80, 100]);
+    });
+
+    it('should not throttle when rpsLimit is not provided', async () => {
+        await common.processBatchWithConcurrency([1, 2, 3], 3, (item) => Promise.resolve(item));
+
+        expect(setTimeoutStub).not.to.have.been.called;
+    });
+
+    it('should sleep the remaining time when a batch completes before minBatchMs', async () => {
+        // batchSize=5, rpsLimit=10 → minBatchMs = 500ms; elapsed = 100ms → wait = 400ms
+        const dateNowStub = sinon.stub(Date, 'now');
+        dateNowStub.onCall(0).returns(0); // batchStart
+        dateNowStub.onCall(1).returns(100); // after Promise.all
+
+        await common.processBatchWithConcurrency([1, 2, 3, 4, 5], 5, (item) => Promise.resolve(item), 10);
+
+        expect(setTimeoutStub).to.have.been.calledOnce;
+        expect(setTimeoutStub.firstCall.args[1]).to.equal(400);
+    });
+
+    it('should not sleep when a batch takes longer than minBatchMs', async () => {
+        // batchSize=5, rpsLimit=10 → minBatchMs = 500ms; elapsed = 600ms → no sleep needed
+        const dateNowStub = sinon.stub(Date, 'now');
+        dateNowStub.onCall(0).returns(0); // batchStart
+        dateNowStub.onCall(1).returns(600); // after Promise.all
+
+        await common.processBatchWithConcurrency([1, 2, 3, 4, 5], 5, (item) => Promise.resolve(item), 10);
+
+        expect(setTimeoutStub).not.to.have.been.called;
+    });
+
+    it('should call onBatchCompleted with the current batch results after each batch', async () => {
+        const items = [1, 2, 3, 4];
+        const processor = (item) => Promise.resolve({ value: item, success: true });
+        const onBatchCompleted = sinon.stub().resolves();
+
+        await common.processBatchWithConcurrency(items, 2, processor, null, onBatchCompleted);
+
+        expect(onBatchCompleted).to.have.been.calledTwice;
+        expect(onBatchCompleted.firstCall.args[0]).to.deep.equal([
+            { value: 1, success: true },
+            { value: 2, success: true },
+        ]);
+        expect(onBatchCompleted.secondCall.args[0]).to.deep.equal([
+            { value: 3, success: true },
+            { value: 4, success: true },
+        ]);
+    });
+
+    it('should throttle once per batch across multiple batches', async () => {
+        // 4 items, batchSize=2, rpsLimit=10 → minBatchMs = 200ms
+        // batch 1: elapsed=50ms → wait=150ms; batch 2: elapsed=50ms → wait=150ms
+        const dateNowStub = sinon.stub(Date, 'now');
+        dateNowStub.onCall(0).returns(0); // batch 1 start
+        dateNowStub.onCall(1).returns(50); // batch 1 end
+        dateNowStub.onCall(2).returns(300); // batch 2 start
+        dateNowStub.onCall(3).returns(350); // batch 2 end
+
+        const results = await common.processBatchWithConcurrency([1, 2, 3, 4], 2, (item) => Promise.resolve(item), 10);
+
+        expect(results).to.deep.equal([1, 2, 3, 4]);
+        expect(setTimeoutStub).to.have.been.calledTwice;
+        expect(setTimeoutStub.firstCall.args[1]).to.equal(150);
+        expect(setTimeoutStub.secondCall.args[1]).to.equal(150);
+    });
+});

--- a/io/studio/test/translation/project-start.test.js
+++ b/io/studio/test/translation/project-start.test.js
@@ -625,6 +625,86 @@ describe('Translation project-start', () => {
             expect(result.statusCode).to.equal(200);
             expect(callCounts['/bin/sendToLocalisationAsync']).to.equal(3);
         });
+
+        it('should call onBatchCompleted with cumulative counts after each versioning batch', async () => {
+            // 15 fragments × 1 locale = 15 items to version → 2 batches (10 + 5) with batchSize=10
+            const items = Array.from({ length: 15 }, (_, i) => `/content/dam/mas/foo/en_US/fragment${i + 1}`);
+            const mockProjectCF = setProjectFields(createMockProjectCF(), { fragments: items });
+
+            setupFetchStub({
+                '/adobe/sites/cf/fragments/test-project-id': responses.ok(mockProjectCF, '"test-etag"'),
+                '/adobe/sites/cf/fragments?path=': (url, options, callCount) =>
+                    responses.ok({ items: [{ id: `version-target-${callCount}` }] }),
+                '/versions': { ok: true },
+            });
+
+            const context = await projectStartService.prepareProjectStart(baseParams);
+            const onBatchCompleted = sinon.stub().resolves();
+
+            await projectStartService.runVersioningStage(context, { onBatchCompleted });
+
+            expect(onBatchCompleted).to.have.been.calledTwice;
+            expect(onBatchCompleted.firstCall.args[0]).to.deep.equal({
+                completedItemCount: 10,
+                failedItemCount: 0,
+                itemCount: 15,
+            });
+            expect(onBatchCompleted.secondCall.args[0]).to.deep.equal({
+                completedItemCount: 15,
+                failedItemCount: 0,
+                itemCount: 15,
+            });
+        });
+
+        it('should apply default rpsLimit of 10 when not provided in params', async () => {
+            // 15 fragments × 1 locale = 15 items to version → 2 batches (batchSize=10)
+            // default rpsLimit=10 → minBatchMs = 10/10*1000 = 1000ms
+            // With Date.now stubbed to 0, elapsed=0 → wait=1000ms per batch
+            const items = Array.from({ length: 15 }, (_, i) => `/content/dam/mas/foo/en_US/fragment${i + 1}`);
+            const mockProjectCF = setProjectFields(createMockProjectCF(), { fragments: items });
+
+            sinon.stub(Date, 'now').returns(0);
+
+            setupFetchStub({
+                '/adobe/sites/cf/fragments/test-project-id': responses.ok(mockProjectCF, '"test-etag"'),
+                '/adobe/sites/cf/fragments?path=': (url, options, callCount) =>
+                    responses.ok({ items: [{ id: `version-target-${callCount}` }] }),
+                '/versions': { ok: true },
+                '/bin/sendToLocalisationAsync': { ok: true },
+            });
+
+            const result = await executeProjectStart(projectStartService, baseParams);
+
+            expect(result.statusCode).to.equal(200);
+            // 2 versioning batches → 2 throttle sleeps at 1000ms each
+            const throttleCalls = global.setTimeout.args.filter(([, delay]) => delay === 1000);
+            expect(throttleCalls).to.have.lengthOf(2);
+        });
+
+        it('should use rpsLimit from params when provided', async () => {
+            // 15 fragments × 1 locale = 15 items to version → 3 batches (batchSize=5)
+            // rpsLimit=10 → minBatchMs = 5/10*1000 = 500ms (batchSize≤rpsLimit: burst stays within limit)
+            // With Date.now stubbed to 0, elapsed=0 → wait=500ms per batch
+            const items = Array.from({ length: 15 }, (_, i) => `/content/dam/mas/foo/en_US/fragment${i + 1}`);
+            const mockProjectCF = setProjectFields(createMockProjectCF(), { fragments: items });
+
+            sinon.stub(Date, 'now').returns(0);
+
+            setupFetchStub({
+                '/adobe/sites/cf/fragments/test-project-id': responses.ok(mockProjectCF, '"test-etag"'),
+                '/adobe/sites/cf/fragments?path=': (url, options, callCount) =>
+                    responses.ok({ items: [{ id: `version-target-${callCount}` }] }),
+                '/versions': { ok: true },
+                '/bin/sendToLocalisationAsync': { ok: true },
+            });
+
+            const result = await executeProjectStart(projectStartService, { ...baseParams, batchSize: 5, rpsLimit: 10 });
+
+            expect(result.statusCode).to.equal(200);
+            // 3 versioning batches → 3 throttle sleeps at 500ms each
+            const throttleCalls = global.setTimeout.args.filter(([, delay]) => delay === 500);
+            expect(throttleCalls).to.have.lengthOf(3);
+        });
     });
 
     describe('Localization request payload', () => {

--- a/io/www/src/fragment/locales.js
+++ b/io/www/src/fragment/locales.js
@@ -1,3 +1,5 @@
+import { PATH_TOKENS } from './utils/paths.js';
+
 const COUNTRY_DATA = {
     AE: { name: 'United Arab Emirates', flag: '🇦🇪' },
     AR: { name: 'Argentina', flag: '🇦🇷' },
@@ -505,6 +507,27 @@ export function getRegionLocales(surface, localeCode, includeDefault) {
         regionLocalesCache[cacheKey] = regionLocales;
     }
     return regionLocalesCache[cacheKey];
+}
+
+/**
+ * Whether a variation’s path locale belongs to the same default-locale “family” as the selected
+ * locale (base locale plus regional variants for the surface). Used when filtering fragment references
+ * in the studio so locale/grouped lists stay aligned with {@link getRegionLocales}.
+ *
+ * @param {string} surface - e.g. 'acom'
+ * @param {string} selectedLocale - Locale segment to match (e.g. 'en_US')
+ * @param {string} variationPath - Full AEM path of the variation
+ * @returns {boolean}
+ */
+export function isVariationPathInParentLocaleFamily(surface, selectedLocale, variationPath) {
+    if (!surface || !variationPath) return false;
+    const selectedLangAndCountry = getLocaleByCode(selectedLocale);
+    if (!selectedLangAndCountry) return false;
+    const regionLocales = getRegionLocales(surface, selectedLocale);
+    const pathMatch = variationPath.match(PATH_TOKENS);
+    const variationLocaleCode = pathMatch?.groups?.parsedLocale ?? null;
+    if (!variationLocaleCode) return false;
+    return [selectedLangAndCountry, ...regionLocales].some((localeEntry) => variationLocaleCode === getLocaleCode(localeEntry));
 }
 
 export function getLanguageName(lang) {

--- a/io/www/test/fragment/locales.test.js
+++ b/io/www/test/fragment/locales.test.js
@@ -10,6 +10,7 @@ import {
     getSurfaceLocales,
     getRegionLocales,
     getLanguageName,
+    isVariationPathInParentLocaleFamily,
 } from '../../src/fragment/locales.js';
 
 describe('locales', function () {
@@ -273,6 +274,43 @@ describe('locales', function () {
             for (const surface of surfacesWithHKRegion) {
                 expect(getDefaultLocaleCode(surface, 'zh_HK'), surface).to.equal('zh_TW');
             }
+        });
+    });
+
+    describe('isVariationPathInParentLocaleFamily', function () {
+        const basePath = (localeSegment, rest = 'folder/fragment') => `/content/dam/mas/acom/${localeSegment}/${rest}`;
+
+        it('should return true when variation path uses the same locale as selected', function () {
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_US', basePath('en_US'))).to.equal(true);
+        });
+
+        it('should return true when variation path uses a regional variant of the selected default locale', function () {
+            // en_US on acom includes en_AE, en_CA, etc. (see ACOM en + US regions)
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_US', basePath('en_AE'))).to.equal(true);
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_US', basePath('en_CA'))).to.equal(true);
+        });
+
+        it('should return true for en_GB regional paths when en_GB is selected', function () {
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_GB', basePath('en_AU'))).to.equal(true);
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_GB', basePath('en_IN'))).to.equal(true);
+        });
+
+        it('should return false when variation locale is not in the selected locale family', function () {
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_US', basePath('fr_FR'))).to.equal(false);
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_GB', basePath('en_US'))).to.equal(false);
+        });
+
+        it('should return false when surface or variation path is missing', function () {
+            expect(isVariationPathInParentLocaleFamily('', 'en_US', basePath('en_US'))).to.equal(false);
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_US', '')).to.equal(false);
+        });
+
+        it('should return false when selectedLocale cannot be parsed as a locale code', function () {
+            expect(isVariationPathInParentLocaleFamily('acom', 'invalid', basePath('en_US'))).to.equal(false);
+        });
+
+        it('should return false when variation path does not match DAM path shape', function () {
+            expect(isVariationPathInParentLocaleFamily('acom', 'en_US', 'not-a-dam-path')).to.equal(false);
         });
     });
 });

--- a/nala/studio/studio.page.js
+++ b/nala/studio/studio.page.js
@@ -26,6 +26,26 @@ export default class StudioPage {
         this.tableViewHeaders = page.locator('sp-table-head');
         this.tableViewRows = this.tableView.locator('sp-table-row');
         this.tableViewFragmentTable = (fragmentId) => this.tableView.locator(`mas-fragment-table[data-id="${fragmentId}"]`);
+        this.groupedVariationsTab = (parentFragmentId) =>
+            this.tableView.locator(
+                `mas-fragment:has(mas-fragment-table[data-id="${parentFragmentId}"]) mas-fragment-variations sp-tab[value="grouped"]`,
+            );
+        this.groupedVariationsTabPanel = (parentFragmentId) =>
+            this.tableView.locator(
+                `mas-fragment:has(mas-fragment-table[data-id="${parentFragmentId}"]) mas-fragment-variations sp-tab-panel[value="grouped"]`,
+            );
+        this.localeVariationsTabPanel = (parentFragmentId) =>
+            this.tableView.locator(
+                `mas-fragment:has(mas-fragment-table[data-id="${parentFragmentId}"]) mas-fragment-variations sp-tab-panel[value="locale"]`,
+            );
+        this.regionalVariationsTable = (parentFragmentId) =>
+            this.tableView.locator(
+                `mas-fragment:has(mas-fragment-table[data-id="${parentFragmentId}"]) mas-fragment-variations sp-tab-panel[value="locale"] mas-fragment-table`,
+            );
+        this.groupedVariationsTable = (parentFragmentId) =>
+            this.tableView.locator(
+                `mas-fragment:has(mas-fragment-table[data-id="${parentFragmentId}"]) mas-fragment-variations sp-tab-panel[value="grouped"] mas-fragment-table`,
+            );
         this.tableViewRowByFragmentId = (fragmentId) => this.tableView.locator(`sp-table-row[value="${fragmentId}"]`);
         this.tableViewPathCell = (row) => row.locator('sp-table-cell.name');
         this.tableViewTitleCell = (row) => row.locator('sp-table-cell.title');

--- a/nala/studio/studio.spec.js
+++ b/nala/studio/studio.spec.js
@@ -115,5 +115,23 @@ export default {
             browserParams: '#page=content&path=nala',
             tags: '@mas-studio @nala @personalization',
         },
+        {
+            tcid: '13',
+            name: '@studio-variations-locale-filter',
+            path: '/studio.html',
+            browserParams: '#page=content&path=nala&query=',
+            data: {
+                usCardId: '8a338eba-55bf-4720-ab6d-79efd60177f6',
+                gbCardId: 'c2de5510-d259-4cf5-9a0c-32d8b538f31c',
+                deCardId: 'b8f54775-22ba-4304-b4af-60938f433482',
+                query: 'card-with-locale-and-grouped-variations',
+                localeVariationEnQaId: 'dd9a638e-8b19-4df5-8417-7fc405b58a1d',
+                groupedVariationDeDeId: 'd02ab931-311c-415b-8ee9-347340c9b43c',
+                groupedVariationPlPlId: '88b1bf05-80e8-4865-991d-dbbdd4257f43',
+                localeEnglishGb: { label: 'English (GB)', value: 'en_GB' },
+                localeGermanDe: { label: 'German (DE)', value: 'de_DE' },
+            },
+            tags: '@mas-studio @regional-variations @grouped-variations',
+        },
     ],
 };

--- a/nala/studio/studio.test.js
+++ b/nala/studio/studio.test.js
@@ -396,4 +396,69 @@ test.describe('M@S Studio feature test suite', () => {
             await expect(studio.contentTableBody.getByText(/All other fragments\s*\(/)).toHaveCount(0);
         });
     });
+
+    // @studio-variations-locale-filter — Locale and grouped variation visibility per studio locale (Nala)
+    test(`${features[13].name},${features[13].tags}`, async ({ page, baseURL }) => {
+        const { data } = features[13];
+        const testPage = `${baseURL}${features[13].path}${miloLibs}${features[13].browserParams}${data.query}`;
+        setTestPage(testPage);
+
+        /**
+         * The default en_US card is translated to en_GB and de_DE. It has one locale variation (en_QA), and
+         * two grouped variations: de_DE, and pl_PL, both not translated.
+         */
+
+        await test.step('step-1: en_US — locale and grouped variations are displayed', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+            await studio.switchToTableView();
+            await page.waitForTimeout(2000);
+            const rootRow = studio.tableViewFragmentTable(data.usCardId);
+            await expect(rootRow).toBeVisible({ timeout: 15000 });
+            await rootRow.locator('button.expand-button').click();
+            await expect(studio.regionalVariationsTable(data.usCardId)).toHaveCount(1, { timeout: 15000 });
+            await expect(studio.tableViewFragmentTable(data.localeVariationEnQaId)).toBeVisible({ timeout: 15000 });
+            await studio.groupedVariationsTab(data.usCardId).click();
+            await expect(studio.groupedVariationsTable(data.usCardId)).toHaveCount(2, { timeout: 15000 });
+            await expect(studio.tableViewFragmentTable(data.groupedVariationDeDeId)).toBeVisible({ timeout: 15000 });
+            await expect(studio.tableViewFragmentTable(data.groupedVariationPlPlId)).toBeVisible({ timeout: 15000 });
+        });
+
+        await test.step('step-2: en_GB — locale or grouped variations are not displayed', async () => {
+            await studio.selectLocale(data.localeEnglishGb.label);
+            await expect(studio.localePicker).toHaveAttribute('value', data.localeEnglishGb.value);
+            await page.waitForLoadState('domcontentloaded');
+            await studio.switchToTableView();
+            await page.waitForTimeout(2000);
+            const fragmentRow = studio.tableViewRowByFragmentId(data.gbCardId);
+            await expect(fragmentRow).toBeVisible();
+            await fragmentRow.locator('button.expand-button').click();
+            await expect(studio.localeVariationsTabPanel(data.gbCardId).getByText('No locale variations found')).toBeVisible({
+                timeout: 15000,
+            });
+            await studio.groupedVariationsTab(data.gbCardId).click();
+            await expect(studio.groupedVariationsTabPanel(data.gbCardId).getByText('No grouped variations found')).toBeVisible({
+                timeout: 15000,
+            });
+        });
+
+        await test.step('step-3: de_DE — locale or grouped variations are not displayed', async () => {
+            await studio.selectLocale(data.localeGermanDe.label);
+            await expect(studio.localePicker).toHaveAttribute('value', data.localeGermanDe.value);
+            await page.waitForLoadState('domcontentloaded');
+            await studio.switchToTableView();
+            await page.waitForTimeout(2000);
+            const fragmentRow = studio.tableViewRowByFragmentId(data.deCardId);
+            await expect(fragmentRow).toBeVisible();
+            await fragmentRow.locator('button.expand-button').click();
+            await expect(studio.localePicker).toHaveAttribute('value', data.localeGermanDe.value);
+            await expect(studio.localeVariationsTabPanel(data.deCardId).getByText('No locale variations found')).toBeVisible({
+                timeout: 15000,
+            });
+            await studio.groupedVariationsTab(data.deCardId).click();
+            await expect(studio.groupedVariationsTabPanel(data.deCardId).getByText('No grouped variations found')).toBeVisible({
+                timeout: 15000,
+            });
+        });
+    });
 });

--- a/studio/src/aem/aem-tag-picker-field.js
+++ b/studio/src/aem/aem-tag-picker-field.js
@@ -1,50 +1,17 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { AEM } from './aem.js';
-import { EVENT_OST_OFFER_SELECT } from '../constants.js';
+import { AEM_TAG_PATH_PRODUCT_CODE_ROOT, EVENT_OST_OFFER_SELECT } from '../constants.js';
 import { isPznCountryTagPath } from '../common/utils/personalization-utils.js';
 import { VARIANTS } from '../editors/variant-picker.js';
 import { getItemFieldState } from '../utils/field-state.js';
+import { getService } from '../utils.js';
+import { AEM_TAG_PATTERN, fromAttribute, toAttribute } from './tag-path-utils.js';
+import { getNamespaceCache, setNamespaceCache } from './tag-cache.js';
 
-const AEM_TAG_PATTERN = /^[a-zA-Z][a-zA-Z0-9]*:/;
-const namespaces = {};
+const PRODUCT_CODE_TAG_PREFIX = `${AEM_TAG_PATH_PRODUCT_CODE_ROOT}/`;
 const SELECTION_CHECKBOX = 'checkbox';
 const SELECTION_CHECKBOX_TAGS = 'checkbox-tags';
-
-/**
- * Converts from attribute (tag format) to property (path format).
- * e.g. "mas:product/photoshop" --> "/content/cq:tags/mas/product/photoshop"
- */
-export function fromAttribute(value) {
-    if (!value) return [];
-    const tags = value.split(',');
-    return tags
-        .map((tag) => tag.trim())
-        .map((tag) => {
-            if (AEM_TAG_PATTERN.test(tag) === false) return false;
-            const [namespace, path] = tag.split(':');
-            if (!namespace || !path) return '';
-            return path ? `/content/cq:tags/${namespace}/${path}` : '';
-        })
-        .filter(Boolean);
-}
-
-/**
- * Converts from property (path format) to attribute (tag format).
- * e.g. "/content/cq:tags/mas/product/photoshop" --> "mas:product/photoshop"
- */
-export function toAttribute(value) {
-    const tags = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : [];
-    if (tags.length === 0) return '';
-    return tags
-        .map((path) => {
-            if (AEM_TAG_PATTERN.test(path)) return path;
-            const match = path.match(/\/content\/cq:tags\/([^/]+)\/(.+)$/);
-            return match ? `${match[1]}:${match[2]}` : '';
-        })
-        .filter(Boolean)
-        .join(',');
-}
 
 class AemTagPickerField extends LitElement {
     static properties = {
@@ -225,13 +192,73 @@ class AemTagPickerField extends LitElement {
         this.personalizationEnabled = false;
     }
 
-    #onOstSelect = ({ detail: { offer } }) => {
+    async #getOfferProductArrangementCode(offerSelectorId, offer) {
+        if (offer?.productArrangementCode) {
+            return offer.productArrangementCode;
+        }
+
+        if (!offerSelectorId) {
+            return undefined;
+        }
+
+        try {
+            const service = getService();
+            if (!service?.collectPriceOptions || !service?.resolveOfferSelectors) {
+                return undefined;
+            }
+
+            const priceOptions = service.collectPriceOptions({ wcsOsi: offerSelectorId });
+            const [offersPromise] = service.resolveOfferSelectors(priceOptions);
+            const [resolvedOffer] = (await offersPromise) || [];
+
+            return resolvedOffer?.productArrangementCode;
+        } catch {
+            return undefined;
+        }
+    }
+
+    #getProductCodeTagPaths(productCode, productArrangementCode) {
+        const normalizedProductCode = String(productCode || '').toLowerCase();
+        const normalizedPac = String(productArrangementCode || '').toLowerCase();
+
+        if (normalizedPac && this.#data?.values) {
+            const pacTag = [...this.#data.values()].find(
+                (tag) => tag.path.startsWith(PRODUCT_CODE_TAG_PREFIX) && tag.path.toLowerCase().endsWith(`/${normalizedPac}`),
+            );
+
+            if (pacTag) {
+                const relativePath = pacTag.path.replace(PRODUCT_CODE_TAG_PREFIX, '');
+                const parts = relativePath.split('/').filter(Boolean);
+
+                let currentPath = AEM_TAG_PATH_PRODUCT_CODE_ROOT;
+                return parts.reduce((paths, part) => {
+                    currentPath += `/${part}`;
+                    paths.push(currentPath);
+                    return paths;
+                }, []);
+            }
+        }
+
+        if (!normalizedProductCode) {
+            return [];
+        }
+
+        const parentTagPath = `${AEM_TAG_PATH_PRODUCT_CODE_ROOT}/${normalizedProductCode}`;
+        return [parentTagPath];
+    }
+
+    #onOstSelect = async ({ detail: { offerSelectorId, offer } }) => {
         if (!offer) return;
+        if (this.#data instanceof Promise) {
+            await this.#data;
+        }
+        const productArrangementCode = await this.#getOfferProductArrangementCode(offerSelectorId, offer);
         const extractedOffer = {
             offer_type: offer.offer_type,
             planType: offer.planType,
             customer_segment: offer.customer_segment,
             product_code: offer.product_code,
+            product_arrangement_code: productArrangementCode,
             market_segments:
                 Array.isArray(offer.market_segments) && offer.market_segments.length > 0
                     ? offer.market_segments[0]
@@ -248,21 +275,24 @@ class AemTagPickerField extends LitElement {
         const existingTags = this.#asValueArray().filter((tagPath) => {
             for (const category of categoriesToUpdate) {
                 if (tagPath.includes(`/content/cq:tags/mas/${category}/`)) {
-                    return false; // Exclude this tagPath if it contains any of the categories
+                    return false;
                 }
             }
             return true;
         });
 
         const newTagPaths = Object.entries(extractedOffer)
-            .filter(([_, value]) => value != null) // Filter out null/undefined values
-            .map(([key, value]) => {
+            .filter(([key, value]) => value != null && key !== 'product_arrangement_code')
+            .flatMap(([key, value]) => {
                 const formattedKey = convertCamelToSnake(key);
+                if (formattedKey === 'product_code') {
+                    return this.#getProductCodeTagPaths(value, extractedOffer.product_arrangement_code);
+                }
                 const formattedValue = String(value).toLowerCase();
-                return `/content/cq:tags/mas/${formattedKey}/${formattedValue}`;
+                return [`/content/cq:tags/mas/${formattedKey}/${formattedValue}`];
             });
 
-        this.value = [...existingTags, ...newTagPaths].filter(Boolean);
+        this.value = this.#normalizeProductCodeTags([...existingTags, ...newTagPaths].filter(Boolean));
         this.#notifyChange();
     };
 
@@ -305,11 +335,11 @@ class AemTagPickerField extends LitElement {
 
     // Returns the cached data for this namespace (if loaded)
     get #data() {
-        return namespaces[this.namespace];
+        return getNamespaceCache(this.namespace);
     }
 
     get allTags() {
-        return namespaces[this.namespace];
+        return getNamespaceCache(this.namespace);
     }
 
     get selectedTags() {
@@ -337,16 +367,16 @@ class AemTagPickerField extends LitElement {
 
     async loadTags() {
         if (!this.#data) {
-            // Not loaded yet, create a placeholder Promise
             let resolveNamespace;
-            namespaces[this.namespace] = new Promise((resolve) => {
-                resolveNamespace = resolve;
-            });
-            // Fetch from AEM
+            setNamespaceCache(
+                this.namespace,
+                new Promise((resolve) => {
+                    resolveNamespace = resolve;
+                }),
+            );
             const rawTags = await this.#aem.tags.list(this.namespace);
             if (!rawTags) return;
-            // Store as a Map keyed by tag path
-            namespaces[this.namespace] = new Map(rawTags.hits.map((tag) => [tag.path, tag]));
+            setNamespaceCache(this.namespace, new Map(rawTags.hits.map((tag) => [tag.path, tag])));
             resolveNamespace();
         } else if (this.#data instanceof Promise) {
             // If still loading, wait
@@ -361,7 +391,9 @@ class AemTagPickerField extends LitElement {
         if ([SELECTION_CHECKBOX, SELECTION_CHECKBOX_TAGS].includes(this.selection)) {
             let tagsForCheckboxList = allTags.filter((tag) => this.#getTagTextByMode(tag));
 
-            if (this.isCheckboxTagsMode) {
+            if (this.top === 'product_code') {
+                tagsForCheckboxList = this.#filterToParentProductCodeTags(tagsForCheckboxList);
+            } else if (this.isCheckboxTagsMode) {
                 tagsForCheckboxList = this.#filterOutParentsWithChildren(tagsForCheckboxList);
             }
 
@@ -400,6 +432,16 @@ class AemTagPickerField extends LitElement {
         return tags.filter((tag) => !parentPaths.has(tag.path));
     }
 
+    #filterToParentProductCodeTags(tags) {
+        return tags.filter((tag) => {
+            const root = this.#rootForPath(tag.path);
+            if (!root) return false;
+
+            const relativePath = tag.path.slice(root.length);
+            return relativePath && !relativePath.includes('/');
+        });
+    }
+
     buildHierarchy(tags) {
         const root = new Map();
         tags.forEach((tag) => {
@@ -432,19 +474,44 @@ class AemTagPickerField extends LitElement {
         const isMultiSelection = this.multiple || this.isCheckboxTagsMode;
 
         if (!isMultiSelection) {
-            // single select
-            this.value = [storedPath];
+            this.value = this.#normalizeProductCodeTags([storedPath]);
             await this.#notifyChange();
             return;
         }
         // multi select
-        const hasEquivalent = currentValue.some((value) => equivalentValues.has(value));
+        const hasEquivalent = currentValue.some((value) => {
+            const valuePath = this.#toPath(value);
+            return equivalentValues.has(value) || equivalentValues.has(valuePath);
+        });
         if (!hasEquivalent) {
             currentValue.push(storedPath);
         } else {
-            currentValue = currentValue.filter((value) => !equivalentValues.has(value));
+            currentValue = currentValue.filter((value) => {
+                const valuePath = this.#toPath(value);
+
+                if (equivalentValues.has(value) || equivalentValues.has(valuePath)) {
+                    return false;
+                }
+
+                if (equivalentPath.startsWith(PRODUCT_CODE_TAG_PREFIX) && valuePath.startsWith(PRODUCT_CODE_TAG_PREFIX)) {
+                    const selectedParts = equivalentPath.replace(PRODUCT_CODE_TAG_PREFIX, '').split('/').filter(Boolean);
+
+                    const valueParts = valuePath.replace(PRODUCT_CODE_TAG_PREFIX, '').split('/').filter(Boolean);
+
+                    const isParentOfSelected =
+                        selectedParts.length > 1 &&
+                        valueParts.length < selectedParts.length &&
+                        valueParts.every((part, index) => part === selectedParts[index]);
+
+                    if (isParentOfSelected) {
+                        return false;
+                    }
+                }
+
+                return true;
+            });
         }
-        this.value = currentValue;
+        this.value = this.#normalizeProductCodeTags(currentValue);
         await this.#notifyChange();
     }
 
@@ -486,6 +553,31 @@ class AemTagPickerField extends LitElement {
                 .filter(Boolean);
         }
         return [];
+    }
+
+    #normalizeProductCodeTags(values) {
+        const normalizedPaths = new Set();
+        this.#asValueArray(values)
+            .map((value) => this.#toPath(value))
+            .filter(Boolean)
+            .forEach((path) => {
+                normalizedPaths.add(path);
+                if (!path.startsWith(PRODUCT_CODE_TAG_PREFIX)) {
+                    return;
+                }
+                const relativePath = path.replace(PRODUCT_CODE_TAG_PREFIX, '');
+                const parts = relativePath.split('/').filter(Boolean);
+                if (parts.length < 2) {
+                    return;
+                }
+                let currentPath = AEM_TAG_PATH_PRODUCT_CODE_ROOT;
+                parts.slice(0, -1).forEach((part) => {
+                    currentPath += `/${part}`;
+                    normalizedPaths.add(currentPath);
+                });
+            });
+
+        return [...normalizedPaths].map((path) => this.#toStoredValue(path));
     }
 
     #selectedPaths(values = this.value) {

--- a/studio/src/aem/fragment.js
+++ b/studio/src/aem/fragment.js
@@ -1,4 +1,6 @@
-import { PATH_TOKENS, PZN_FOLDER, TAG_PROMOTION_PREFIX } from '../constants.js';
+import { PATH_TOKENS, PZN_FOLDER, TAG_PROMOTION_PREFIX, MAS_PRODUCT_CODE_PREFIX } from '../constants.js';
+import { getCachedTagTitle } from './tag-cache.js';
+import { formatProductCodeNestedTitle, normalizeTagId } from './tag-id-utils.js';
 
 export class Fragment {
     path = '';
@@ -49,6 +51,41 @@ export class Fragment {
     getTagTitle(id) {
         const tags = this.tags.filter((tag) => tag.id.includes(id));
         return tags[0]?.title;
+    }
+
+    getCurrentTagTitle(id) {
+        const fieldTagValues = this.getField('tags')?.values;
+        const rawTagIds = this.newTags ?? (fieldTagValues?.length ? fieldTagValues : null) ?? this.tags ?? [];
+        const tagIds = rawTagIds.map(normalizeTagId).filter(Boolean);
+
+        const matchingIds = tagIds.filter((tagId) => tagId.includes(id));
+        if (!matchingIds.length) return undefined;
+
+        const matchingId = [...matchingIds].sort((a, b) => b.length - a.length)[0];
+        const tags = Array.isArray(this.tags) ? this.tags : [];
+
+        const exactTag = tags.find((tag) => normalizeTagId(tag) === matchingId);
+        const cachedTitle = getCachedTagTitle(matchingId);
+        const fallbackTag = tags.find((tag) => {
+            const tagId = normalizeTagId(tag);
+            return tagId && (tagId.includes(matchingId) || matchingId.includes(tagId));
+        });
+
+        const title = exactTag?.title || cachedTitle || fallbackTag?.title;
+
+        if (id === MAS_PRODUCT_CODE_PREFIX) {
+            const nestedTitle = formatProductCodeNestedTitle(title, matchingId);
+            if (nestedTitle) return nestedTitle;
+        }
+
+        if (title) return title;
+
+        const fallback = matchingId.split('/').filter(Boolean).pop();
+        return fallback
+            ?.split(/[-_]/)
+            .filter(Boolean)
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(' ');
     }
 
     get locale() {

--- a/studio/src/aem/fragment.js
+++ b/studio/src/aem/fragment.js
@@ -1,6 +1,7 @@
 import { PATH_TOKENS, PZN_FOLDER, TAG_PROMOTION_PREFIX, MAS_PRODUCT_CODE_PREFIX } from '../constants.js';
 import { getCachedTagTitle } from './tag-cache.js';
 import { formatProductCodeNestedTitle, normalizeTagId } from './tag-id-utils.js';
+import { isVariationPathInParentLocaleFamily } from '../../../io/www/src/fragment/locales.js';
 
 export class Fragment {
     path = '';
@@ -369,7 +370,9 @@ export class Fragment {
             if (!reference) continue;
 
             if (Fragment.isGroupedVariationPath(path)) {
-                grouped.push(reference);
+                if (isVariationPathInParentLocaleFamily(surface, currentLocale, path)) {
+                    grouped.push(reference);
+                }
                 continue;
             }
 
@@ -383,7 +386,12 @@ export class Fragment {
                 const refMatch = path.match(PATH_TOKENS);
                 if (refMatch?.groups) {
                     const r = refMatch.groups;
-                    if (r.surface === surface && r.fragmentPath === fragmentPath && r.parsedLocale !== currentLocale) {
+                    if (
+                        r.surface === surface &&
+                        r.fragmentPath === fragmentPath &&
+                        r.parsedLocale !== currentLocale &&
+                        isVariationPathInParentLocaleFamily(surface, currentLocale, path)
+                    ) {
                         locale.push(reference);
                     }
                 }

--- a/studio/src/aem/mas-filter-panel.js
+++ b/studio/src/aem/mas-filter-panel.js
@@ -111,10 +111,15 @@ class MasFilterPanel extends LitElement {
                 }
                 // Get values after the type
                 const values = parts.slice(typeIndex);
-                // Construct the full path
-                const fullPath = `/content/cq:tags/mas/${tagPath}`;
-                // Get the title from the last value
-                const title = values.length > 0 ? values[values.length - 1].toUpperCase() : '';
+                let fullPath = `/content/cq:tags/mas/${tagPath}`;
+                let title = values.length > 0 ? values[values.length - 1].toUpperCase() : '';
+                // For product_code, collapse child selections
+                // back to the parent product for display in the filter chips
+                if (type === 'product_code' && values.length > 1) {
+                    const parentValue = values[0];
+                    fullPath = `/content/cq:tags/mas/${type}/${parentValue}`;
+                    title = parentValue.toUpperCase();
+                }
 
                 const picker = this.shadowRoot.querySelector(`aem-tag-picker-field[top="${type}"]`);
                 picker?.allTags.then?.(() => {
@@ -138,16 +143,18 @@ class MasFilterPanel extends LitElement {
                     }
                 });
 
+                const nextTag = {
+                    path: fullPath,
+                    title: selectedTagTitle || title,
+                    top: type,
+                };
+
+                const existingTags = acc[type] || [];
+                const alreadyExists = existingTags.some((tag) => tag.path === nextTag.path);
+
                 return {
                     ...acc,
-                    [type]: [
-                        ...(acc[type] || []),
-                        {
-                            path: fullPath,
-                            title: selectedTagTitle || title,
-                            top: type,
-                        },
-                    ],
+                    [type]: alreadyExists ? existingTags : [...existingTags, nextTag],
                 };
             },
             { ...EMPTY_TAGS },
@@ -181,8 +188,38 @@ class MasFilterPanel extends LitElement {
         }
     }
 
+    #expandProductCodeTags(tags) {
+        const picker = this.shadowRoot.querySelector('aem-tag-picker-field[top="product_code"]');
+        const allTags = picker?.allTags;
+
+        if (!picker || !allTags || allTags instanceof Promise) {
+            return tags;
+        }
+
+        const rootPath = `${picker.namespace}/${picker.top}/`;
+        const availableTags = [...allTags.values()].filter((tag) => tag.path.startsWith(rootPath));
+
+        return tags.flatMap((tag) => {
+            const descendants = availableTags.filter((candidate) => candidate.path.startsWith(`${tag.path}/`));
+
+            const leafDescendants = descendants.filter(
+                (candidate) =>
+                    !availableTags.some(
+                        (other) => other.path !== candidate.path && other.path.startsWith(`${candidate.path}/`),
+                    ),
+            );
+
+            return leafDescendants.length ? leafDescendants : [tag];
+        });
+    }
+
     #updateFiltersParams() {
-        const tagValues = Object.values(this.tagsByType ?? EMPTY_TAGS)
+        const expandedTagsByType = {
+            ...this.tagsByType,
+            product_code: this.#expandProductCodeTags(this.tagsByType.product_code || []),
+        };
+
+        const tagValues = Object.values(expandedTagsByType)
             .flat()
             .map((tag) => pathToTagId(tag.path))
             .filter(Boolean);

--- a/studio/src/aem/tag-cache.js
+++ b/studio/src/aem/tag-cache.js
@@ -1,0 +1,35 @@
+import { fromAttribute } from './tag-path-utils.js';
+
+const namespaces = {};
+
+/**
+ * @param {string} namespace
+ * @returns {Map<string, object>|Promise<void>|undefined}
+ */
+export function getNamespaceCache(namespace) {
+    return namespaces[namespace];
+}
+
+/**
+ * @param {string} namespace
+ * @param {Map<string, object>|Promise<void>} value
+ */
+export function setNamespaceCache(namespace, value) {
+    namespaces[namespace] = value;
+}
+
+/**
+ * Resolves a display title from the in-memory tag taxonomy cache
+ * @param {string} tagOrPath
+ * @param {string} [namespace='/content/cq:tags/mas']
+ * @returns {string|undefined}
+ */
+export function getCachedTagTitle(tagOrPath, namespace = '/content/cq:tags/mas') {
+    const data = namespaces[namespace];
+    if (!data || data instanceof Promise) return undefined;
+
+    const path = tagOrPath?.startsWith('/content/cq:tags/') ? tagOrPath : fromAttribute(tagOrPath)?.[0];
+    if (!path) return undefined;
+
+    return data.get(path)?.title;
+}

--- a/studio/src/aem/tag-id-utils.js
+++ b/studio/src/aem/tag-id-utils.js
@@ -1,0 +1,35 @@
+import { MAS_PRODUCT_CODE_PREFIX } from '../constants.js';
+
+/**
+ * Normalizes tag references to short "mas:path/to/tag" form
+ * @param {string|{id?: string, path?: string}} tag
+ * @returns {string}
+ */
+export function normalizeTagId(tag) {
+    const rawValue = typeof tag === 'string' ? tag : tag?.id || tag?.path || '';
+    if (!rawValue) return '';
+
+    if (rawValue.startsWith('/content/cq:tags/')) {
+        const match = rawValue.match(/\/content\/cq:tags\/([^/]+)\/(.+)$/);
+        return match ? `${match[1]}:${match[2]}` : '';
+    }
+
+    return rawValue;
+}
+
+/**
+ * Formats product_code tag title with PAC suffix when a nested leaf is selected
+ * @param {string} title
+ * @param {string} matchingId - normalized tag id starting with mas:product_code/
+ * @returns {string|undefined}
+ */
+export function formatProductCodeNestedTitle(title, matchingId) {
+    const productCodePath = matchingId.replace(MAS_PRODUCT_CODE_PREFIX, '');
+    const parts = productCodePath.split('/').filter(Boolean);
+
+    if (parts.length > 1) {
+        const pac = parts[parts.length - 1]?.toUpperCase();
+        if (title && pac) return `${title} (${pac})`;
+    }
+    return undefined;
+}

--- a/studio/src/aem/tag-path-utils.js
+++ b/studio/src/aem/tag-path-utils.js
@@ -1,0 +1,38 @@
+export const AEM_TAG_PATTERN = /^[a-zA-Z][a-zA-Z0-9]*:/;
+
+/**
+ * Converts from attribute (tag format) to path (path format)
+ * @param {string} value
+ * @returns {string[]}
+ */
+export function fromAttribute(value) {
+    if (!value) return [];
+    const tags = value.split(',');
+    return tags
+        .map((tag) => tag.trim())
+        .map((tag) => {
+            if (AEM_TAG_PATTERN.test(tag) === false) return false;
+            const [namespace, path] = tag.split(':');
+            if (!namespace || !path) return '';
+            return path ? `/content/cq:tags/${namespace}/${path}` : '';
+        })
+        .filter(Boolean);
+}
+
+/**
+ * Converts from path (path format) to attribute (tag format)
+ * @param {string[]|string} value
+ * @returns {string}
+ */
+export function toAttribute(value) {
+    const tags = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : [];
+    if (tags.length === 0) return '';
+    return tags
+        .map((path) => {
+            if (AEM_TAG_PATTERN.test(path)) return path;
+            const match = path.match(/\/content\/cq:tags\/([^/]+)\/(.+)$/);
+            return match ? `${match[1]}:${match[2]}` : '';
+        })
+        .filter(Boolean)
+        .join(',');
+}

--- a/studio/src/constants.js
+++ b/studio/src/constants.js
@@ -150,6 +150,12 @@ export const FIELD_MODEL_MAPPING = {
 export const TAG_STUDIO_CONTENT_TYPE = 'mas:studio/content-type';
 export const TAG_PROMOTION_PREFIX = 'mas:promotion/';
 
+/** Full AEM content path for product_code */
+export const AEM_TAG_PATH_PRODUCT_CODE_ROOT = '/content/cq:tags/mas/product_code';
+
+/** Tag id prefix in short form */
+export const MAS_PRODUCT_CODE_PREFIX = 'mas:product_code/';
+
 export const TAG_MODEL_ID_MAPPING = {
     'mas:studio/content-type/merch-card-collection': 'L2NvbmYvbWFzL3NldHRpbmdzL2RhbS9jZm0vbW9kZWxzL2NvbGxlY3Rpb24',
     'mas:studio/content-type/merch-card': 'L2NvbmYvbWFzL3NldHRpbmdzL2RhbS9jZm0vbW9kZWxzL2NhcmQ',

--- a/studio/src/editor-panel.js
+++ b/studio/src/editor-panel.js
@@ -9,6 +9,7 @@ import {
     COLLECTION_MODEL_PATH,
     EVENT_KEYDOWN,
     EVENT_OST_OFFER_SELECT,
+    MAS_PRODUCT_CODE_PREFIX,
     OPERATIONS,
     PAGE_NAMES,
     TAG_PROMOTION_PREFIX,
@@ -37,7 +38,8 @@ export function getFragmentPartsToUse(store, fragment) {
                 variantCode: fragment?.getField('variant')?.values[0],
                 marketSegment: fragment?.getTagTitle('market_segment'),
                 customerSegment: fragment?.getTagTitle('customer_segment'),
-                product: fragment?.getTagTitle('mas:product/'),
+                product_code:
+                    fragment?.getCurrentTagTitle?.(MAS_PRODUCT_CODE_PREFIX) || fragment?.getTagTitle?.('mas:product/'),
                 promotion: fragment?.getTagTitle(TAG_PROMOTION_PREFIX),
             };
 
@@ -50,7 +52,7 @@ export function getFragmentPartsToUse(store, fragment) {
                 if (part) return ` / ${part}`;
                 return '';
             };
-            fragmentParts = `${surface}${buildPart(props.variantLabel)}${buildPart(props.customerSegment)}${buildPart(props.marketSegment)}${buildPart(props.product)}${buildPart(props.promotion)}`;
+            fragmentParts = `${surface}${buildPart(props.variantLabel)}${buildPart(props.customerSegment)}${buildPart(props.marketSegment)}${buildPart(props.product_code)}${buildPart(props.promotion)}`;
             title = props.cardTitle;
             break;
         case COLLECTION_MODEL_PATH:

--- a/studio/src/editors/merch-card-editor.js
+++ b/studio/src/editors/merch-card-editor.js
@@ -19,7 +19,7 @@ import { VARIANT_NAMES } from './variant-picker.js';
 import ReactiveController from '../reactivity/reactive-controller.js';
 import { getItemFieldStateByIndex } from '../utils/field-state.js';
 import { Fragment } from '../aem/fragment.js';
-import { toAttribute } from '../aem/aem-tag-picker-field.js';
+import { toAttribute } from '../aem/tag-path-utils.js';
 import { getGlobalSettingsDefaults } from '../settings/settings-store.js';
 
 const QUANTITY_MODEL = 'quantitySelect';

--- a/studio/src/mas-fragment-editor.js
+++ b/studio/src/mas-fragment-editor.js
@@ -5,7 +5,14 @@ import { prepopulateFragmentCache } from './mas-repository.js';
 import Store from './store.js';
 import ReactiveController from './reactivity/reactive-controller.js';
 import StoreController from './reactivity/store-controller.js';
-import { CARD_MODEL_PATH, COLLECTION_MODEL_PATH, ODIN_PREVIEW_ORIGIN, PAGE_NAMES, TAG_PROMOTION_PREFIX } from './constants.js';
+import {
+    CARD_MODEL_PATH,
+    COLLECTION_MODEL_PATH,
+    MAS_PRODUCT_CODE_PREFIX,
+    ODIN_PREVIEW_ORIGIN,
+    PAGE_NAMES,
+    TAG_PROMOTION_PREFIX,
+} from './constants.js';
 import router from './router.js';
 import { VARIANTS } from './editors/variant-picker.js';
 import { extractLocaleFromPath, generateCodeToUse, getFragmentMapping, replaceLocaleInPath, showToast } from './utils.js';
@@ -567,7 +574,7 @@ export default class MasFragmentEditor extends LitElement {
         // Analytics ID (from tags with mas:product_code/ prefix)
         const productCodeTag = fragment.tags?.find((tag) => tag.id?.startsWith('mas:product_code/'));
         if (productCodeTag) {
-            const analyticsId = productCodeTag.id.replace('mas:product_code/', '');
+            const analyticsId = productCodeTag.id.replace(MAS_PRODUCT_CODE_PREFIX, '');
             if (analyticsId) attrs.analyticsId = analyticsId;
         }
 
@@ -1478,13 +1485,16 @@ export default class MasFragmentEditor extends LitElement {
 
         const variantCode = this.fragment.getField('variant')?.values[0];
         const variantLabel = VARIANTS.find((v) => v.value === variantCode)?.label || '';
-        const customerSegment = this.fragment.getTagTitle('customer_segment') || '';
-        const marketSegment = this.fragment.getTagTitle('market_segment') || '';
-        const product = this.fragment.getTagTitle('mas:product/') || '';
-        const promotion = this.fragment.getTagTitle(TAG_PROMOTION_PREFIX) || '';
+        const customerSegment = this.fragment.getCurrentTagTitle('customer_segment') || '';
+        const marketSegment = this.fragment.getCurrentTagTitle('market_segment') || '';
+        const productCode =
+            this.fragment.getCurrentTagTitle(MAS_PRODUCT_CODE_PREFIX) ||
+            this.fragment.getTagTitle(MAS_PRODUCT_CODE_PREFIX) ||
+            '';
+        const promotion = this.fragment.getCurrentTagTitle(TAG_PROMOTION_PREFIX) || '';
 
         const buildPart = (part) => (part ? ` / ${part}` : '');
-        const fragmentParts = `${surface}${buildPart(variantLabel)}${buildPart(customerSegment)}${buildPart(marketSegment)}${buildPart(product)}${buildPart(promotion)}`;
+        const fragmentParts = `${surface}${buildPart(variantLabel)}${buildPart(customerSegment)}${buildPart(marketSegment)}${buildPart(productCode)}${buildPart(promotion)}`;
 
         return html`<p id="author-path">${modelName}: ${fragmentParts}</p>`;
     }

--- a/studio/src/mas-fragment-variations.js
+++ b/studio/src/mas-fragment-variations.js
@@ -31,11 +31,11 @@ class MasFragmentVariations extends LitElement {
     }
 
     get localeVariations() {
-        return this.fragment.listLocaleVariations() || [];
+        return this.fragment.listLocaleVariations();
     }
 
     get groupedVariations() {
-        return this.fragment.listGroupedVariations() || [];
+        return this.fragment.listGroupedVariations();
     }
 
     get hasLocaleVariations() {

--- a/studio/src/mas-repository.js
+++ b/studio/src/mas-repository.js
@@ -29,6 +29,7 @@ import {
     DICTIONARY_ENTRY_MODEL_ID,
     TAG_STATUS_DRAFT,
     CARD_MODEL_PATH,
+    MAS_PRODUCT_CODE_PREFIX,
     PZN_FOLDER,
     SURFACES,
 } from './constants.js';
@@ -1638,7 +1639,7 @@ export class MasRepository extends LitElement {
      */
     generateGroupedVariationName(fragment, pznTags) {
         const parts = [];
-        const product = fragment.getTagTitle('mas:product/');
+        const product = fragment.getCurrentTagTitle?.(MAS_PRODUCT_CODE_PREFIX) || fragment.getTagTitle?.('mas:product/');
         if (product) parts.push(product);
 
         const customerSegment = fragment.getTagTitle('customer_segment');

--- a/studio/src/utils.js
+++ b/studio/src/utils.js
@@ -1,4 +1,4 @@
-import { CARD_MODEL_PATH, COLLECTION_MODEL_PATH, TAG_PROMOTION_PREFIX } from './constants.js';
+import { CARD_MODEL_PATH, COLLECTION_MODEL_PATH, MAS_PRODUCT_CODE_PREFIX, TAG_PROMOTION_PREFIX } from './constants.js';
 import { VARIANTS } from './editors/variant-picker.js';
 import Events from './events.js';
 import { MAS_ROOT, PATH_TOKENS } from '../../io/www/src/fragment/utils/paths.js';
@@ -205,8 +205,9 @@ export function getFragmentPartsToUse(fragment, path) {
                 variantCode: fragment?.getField('variant')?.values[0],
                 marketSegment: fragment?.getTagTitle('market_segment'),
                 customerSegment: fragment?.getTagTitle('customer_segment'),
-                product: fragment?.getTagTitle('mas:product/'),
-                promotion: fragment?.getTagTitle(TAG_PROMOTION_PREFIX),
+                product_code:
+                    fragment?.getCurrentTagTitle?.(MAS_PRODUCT_CODE_PREFIX) || fragment?.getTagTitle?.('mas:product/'),
+                promotion: fragment?.getCurrentTagTitle?.(TAG_PROMOTION_PREFIX),
             };
 
             VARIANTS.forEach((variant) => {
@@ -218,7 +219,7 @@ export function getFragmentPartsToUse(fragment, path) {
                 if (part) return ` / ${part}`;
                 return '';
             };
-            fragmentParts = `${surface}${buildPart(props.variantLabel)}${buildPart(props.customerSegment)}${buildPart(props.marketSegment)}${buildPart(props.product)}${buildPart(props.promotion)}`;
+            fragmentParts = `${surface}${buildPart(props.variantLabel)}${buildPart(props.customerSegment)}${buildPart(props.marketSegment)}${buildPart(props.product_code)}${buildPart(props.promotion)}`;
             title = props.cardTitle;
             break;
         case COLLECTION_MODEL_PATH:

--- a/studio/test/aem/aem-tag-picker-field.test.html
+++ b/studio/test/aem/aem-tag-picker-field.test.html
@@ -31,7 +31,10 @@
             import { expect } from '@esm-bundle/chai';
             import { fixture, oneEvent } from '@open-wc/testing-helpers/pure';
 
-            import { fromAttribute, toAttribute } from '../../src/aem/aem-tag-picker-field.js';
+            import '../../src/aem/aem-tag-picker-field.js';
+            import { fromAttribute, toAttribute } from '../../src/aem/tag-path-utils.js';
+            import { getCachedTagTitle } from '../../src/aem/tag-cache.js';
+            import { EVENT_OST_OFFER_SELECT } from '../../src/constants.js';
 
             import { delay, initElementFromTemplate } from '../utils.js';
 
@@ -512,6 +515,222 @@
                         expect(overlayTrigger.open).to.be.true;
                     });
                 });
+
+                describe('aem-tag-picker-field: product_code & OST', async () => {
+                    it('normalizes nested product_code leaf to include parent tag paths', async function () {
+                        const picker = initElementFromTemplate('tagPickerProductCode', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const leaf = '/content/cq:tags/mas/product_code/apptype/mypac';
+                        const parent = '/content/cq:tags/mas/product_code/apptype';
+
+                        await picker.toggleTag(leaf);
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.have.members([parent, leaf]);
+                    });
+
+                    it('clears nested product_code selection when toggling leaf off again', async function () {
+                        const picker = initElementFromTemplate('tagPickerProductCode', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const leaf = '/content/cq:tags/mas/product_code/apptype/mypac';
+
+                        await picker.toggleTag(leaf);
+                        await picker.updateComplete;
+                        await picker.toggleTag(leaf);
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.deep.equal([]);
+                    });
+
+                    it('applies OST offer with PAC paths when productArrangementCode matches taxonomy', async function () {
+                        const picker = initElementFromTemplate('tagPickerOstNoTop', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const changePromise = oneEvent(picker, 'change');
+                        document.dispatchEvent(
+                            new CustomEvent(EVENT_OST_OFFER_SELECT, {
+                                bubbles: true,
+                                detail: {
+                                    offerSelectorId: 'test-osi',
+                                    offer: {
+                                        product_code: 'apptype',
+                                        productArrangementCode: 'mypac',
+                                        offer_type: 'base',
+                                    },
+                                },
+                            }),
+                        );
+
+                        await changePromise;
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.include('/content/cq:tags/mas/product_code/apptype/mypac');
+                        expect(picker.value).to.include('/content/cq:tags/mas/offer_type/base');
+                    });
+
+                    it('uses product_code parent only when PAC has no matching tag', async function () {
+                        const picker = initElementFromTemplate('tagPickerOstNoTop', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const changePromise2 = oneEvent(picker, 'change');
+                        document.dispatchEvent(
+                            new CustomEvent(EVENT_OST_OFFER_SELECT, {
+                                bubbles: true,
+                                detail: {
+                                    offerSelectorId: 'test-osi',
+                                    offer: {
+                                        product_code: 'apptype',
+                                        productArrangementCode: 'nonexistent_pac',
+                                        offer_type: 'base',
+                                    },
+                                },
+                            }),
+                        );
+
+                        await changePromise2;
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.include('/content/cq:tags/mas/product_code/apptype');
+                        expect(picker.value).to.not.include('/content/cq:tags/mas/product_code/apptype/mypac');
+                    });
+
+                    it('getCachedTagTitle returns AEM title after tags load', async function () {
+                        const picker = initElementFromTemplate('tagPicker2', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        expect(getCachedTagTitle('/content/cq:tags/mas/status/draft')).to.equal('DRAFT');
+                    });
+
+                    it('OST: resolves tags when mas-commerce-service is missing (getService null, no inline PAC)', async function () {
+                        document.querySelectorAll('mas-commerce-service').forEach((el) => el.remove());
+
+                        const picker = initElementFromTemplate('tagPickerOstNoTop', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const changePromise = oneEvent(picker, 'change');
+                        document.dispatchEvent(
+                            new CustomEvent(EVENT_OST_OFFER_SELECT, {
+                                bubbles: true,
+                                detail: {
+                                    offerSelectorId: 'needs-service-for-pac',
+                                    offer: {
+                                        product_code: 'apptype',
+                                        offer_type: 'base',
+                                    },
+                                },
+                            }),
+                        );
+
+                        await changePromise;
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.include('/content/cq:tags/mas/offer_type/base');
+                        expect(picker.value).to.include('/content/cq:tags/mas/product_code/apptype');
+                        expect(picker.value).to.not.include('/content/cq:tags/mas/product_code/apptype/mypac');
+                    });
+
+                    it('OST: ignores incomplete commerce service (no resolveOfferSelectors)', async function () {
+                        document.querySelectorAll('mas-commerce-service').forEach((el) => el.remove());
+                        const incomplete = document.createElement('mas-commerce-service');
+                        incomplete.collectPriceOptions = () => [];
+                        document.body.appendChild(incomplete);
+
+                        const picker = initElementFromTemplate('tagPickerOstNoTop', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const changePromise = oneEvent(picker, 'change');
+                        document.dispatchEvent(
+                            new CustomEvent(EVENT_OST_OFFER_SELECT, {
+                                bubbles: true,
+                                detail: {
+                                    offerSelectorId: 'osi-incomplete-service',
+                                    offer: {
+                                        product_code: 'apptype',
+                                        offer_type: 'base',
+                                    },
+                                },
+                            }),
+                        );
+
+                        await changePromise;
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.include('/content/cq:tags/mas/product_code/apptype');
+                        incomplete.remove();
+                    });
+
+                    it('OST: survives collectPriceOptions throwing (catch path in PAC resolution)', async function () {
+                        document.querySelectorAll('mas-commerce-service').forEach((el) => el.remove());
+                        const throwingSvc = document.createElement('mas-commerce-service');
+                        throwingSvc.collectPriceOptions = () => {
+                            throw new Error('commerce unavailable');
+                        };
+                        throwingSvc.resolveOfferSelectors = () => [];
+                        document.body.appendChild(throwingSvc);
+
+                        const picker = initElementFromTemplate('tagPickerOstNoTop', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const changePromise = oneEvent(picker, 'change');
+                        document.dispatchEvent(
+                            new CustomEvent(EVENT_OST_OFFER_SELECT, {
+                                bubbles: true,
+                                detail: {
+                                    offerSelectorId: 'osi-throws',
+                                    offer: {
+                                        product_code: 'apptype',
+                                        offer_type: 'base',
+                                    },
+                                },
+                            }),
+                        );
+
+                        await changePromise;
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.include('/content/cq:tags/mas/offer_type/base');
+                        expect(picker.value).to.include('/content/cq:tags/mas/product_code/apptype');
+                        throwingSvc.remove();
+                    });
+
+                    it('OST: empty product_code adds no product_code tag paths', async function () {
+                        document.querySelectorAll('mas-commerce-service').forEach((el) => el.remove());
+
+                        const picker = initElementFromTemplate('tagPickerOstNoTop', this.test.title);
+                        await picker.loadTags();
+                        await picker.updateComplete;
+
+                        const changePromise = oneEvent(picker, 'change');
+                        document.dispatchEvent(
+                            new CustomEvent(EVENT_OST_OFFER_SELECT, {
+                                bubbles: true,
+                                detail: {
+                                    offerSelectorId: 'osi-empty-pc',
+                                    offer: {
+                                        product_code: '',
+                                        offer_type: 'promo',
+                                    },
+                                },
+                            }),
+                        );
+
+                        await changePromise;
+                        await picker.updateComplete;
+
+                        expect(picker.value).to.include('/content/cq:tags/mas/offer_type/promo');
+                        expect(picker.value.filter((p) => p.includes('/content/cq:tags/mas/product_code/'))).to.have.length(0);
+                    });
+                });
             });
         </script>
         <main>
@@ -583,6 +802,17 @@
                 selection="checkbox-tags"
                 display-value
             ></aem-tag-picker-field>
+        </template>
+        <template id="tagPickerProductCode">
+            <aem-tag-picker-field
+                namespace="/content/cq:tags/mas"
+                top="product_code"
+                label="Product code"
+                multiple
+            ></aem-tag-picker-field>
+        </template>
+        <template id="tagPickerOstNoTop">
+            <aem-tag-picker-field namespace="/content/cq:tags/mas" label="Tags"></aem-tag-picker-field>
         </template>
     </body>
 </html>

--- a/studio/test/aem/fragment.test.js
+++ b/studio/test/aem/fragment.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@open-wc/testing';
 import { Fragment } from '../../src/aem/fragment.js';
+import { TAG_PROMOTION_PREFIX } from '../../src/constants.js';
 import generateFragmentStore from '../../src/reactivity/source-fragment-store.js';
 
 describe('Fragment', () => {
@@ -39,8 +40,8 @@ describe('Fragment', () => {
                 createFragmentConfig({
                     path: '/content/dam/mas/sandbox/en_US/my-fragment',
                     references: [
-                        { id: 'ref-1', path: '/content/dam/mas/sandbox/fr_FR/my-fragment' }, // valid
-                        { id: 'ref-2', path: '/content/dam/mas/sandbox/de_DE/my-fragment' }, // valid
+                        { id: 'ref-1', path: '/content/dam/mas/sandbox/en_BE/my-fragment' }, // valid
+                        { id: 'ref-2', path: '/content/dam/mas/sandbox/en_CA/my-fragment' }, // valid
                         { id: 'ref-3', path: '/content/dam/mas/sandbox/en_US/different-fragment' }, // different fragment
                         { id: 'ref-4', path: '/content/dam/mas/acom/en_US/my-fragment' }, // different surface
                         { id: 'ref-5', path: '/invalid/path' }, // invalid path
@@ -72,8 +73,8 @@ describe('Fragment', () => {
                 createFragmentConfig({
                     path: '/content/dam/mas/sandbox/en_US/folder/subfolder/my-fragment',
                     references: [
-                        { id: 'ref-1', path: '/content/dam/mas/sandbox/fr_FR/folder/subfolder/my-fragment' },
-                        { id: 'ref-2', path: '/content/dam/mas/sandbox/fr_FR/folder/my-fragment' },
+                        { id: 'ref-1', path: '/content/dam/mas/sandbox/en_CA/folder/subfolder/my-fragment' },
+                        { id: 'ref-2', path: '/content/dam/mas/sandbox/en_CA/folder/my-fragment' },
                     ],
                 }),
             );
@@ -109,13 +110,13 @@ describe('Fragment', () => {
             const fragment = new Fragment(
                 createFragmentConfig({
                     path: '/content/dam/mas/sandbox/en_US/my-fragment',
-                    references: [{ id: 'ref-1', path: '/content/dam/mas/sandbox/fr_FR/my-fragment' }],
+                    references: [{ id: 'ref-1', path: '/content/dam/mas/sandbox/en_BE/my-fragment' }],
                     fields: [
                         {
                             name: 'variations',
                             values: [
-                                '/content/dam/mas/sandbox/fr_FR/my-fragment',
-                                '/content/dam/mas/sandbox/de_DE/my-fragment',
+                                '/content/dam/mas/sandbox/en_BE/my-fragment',
+                                '/content/dam/mas/sandbox/en_CA/my-fragment',
                             ],
                         },
                     ],
@@ -124,7 +125,7 @@ describe('Fragment', () => {
 
             const variations = fragment.listLocaleVariations();
             expect(variations).to.have.lengthOf(1);
-            expect(variations[0].path).to.equal('/content/dam/mas/sandbox/fr_FR/my-fragment');
+            expect(variations[0].path).to.equal('/content/dam/mas/sandbox/en_BE/my-fragment');
         });
     });
 
@@ -171,6 +172,47 @@ describe('Fragment', () => {
             const groupedVariations = fragment.listGroupedVariations();
             expect(groupedVariations).to.have.lengthOf(1);
             expect(groupedVariations[0].path).to.equal('/content/dam/mas/sandbox/en_US/pzn/my-fragment-a');
+        });
+
+        it('includes grouped paths in the parent locale family even when the reference has promotion tags', () => {
+            const groupedPath = '/content/dam/mas/sandbox/en_US/pzn/my-fragment';
+            const fragment = new Fragment(
+                createFragmentConfig({
+                    path: '/content/dam/mas/sandbox/en_US/my-fragment',
+                    references: [
+                        {
+                            id: 'ref-grouped-promo',
+                            path: groupedPath,
+                            tags: [{ id: `${TAG_PROMOTION_PREFIX}summer-sale` }],
+                        },
+                    ],
+                }),
+            );
+
+            expect(fragment.listGroupedVariations().map((reference) => reference.id)).to.deep.equal(['ref-grouped-promo']);
+            expect(fragment.getPromoVariationCount()).to.equal(0);
+            expect(fragment.listLocaleVariations()).to.have.lengthOf(0);
+        });
+
+        it('does not classify out-of-family grouped paths as promo or locale', () => {
+            const outOfFamilyGroupedPath = '/content/dam/mas/sandbox/fr_FR/pzn/my-fragment';
+            const fragment = new Fragment(
+                createFragmentConfig({
+                    path: '/content/dam/mas/sandbox/en_US/my-fragment',
+                    references: [
+                        {
+                            id: 'ref-out-of-family',
+                            path: outOfFamilyGroupedPath,
+                            tags: [{ id: `${TAG_PROMOTION_PREFIX}misclassified-without-fix` }],
+                        },
+                    ],
+                }),
+            );
+
+            expect(fragment.listGroupedVariations()).to.have.lengthOf(0);
+            expect(fragment.getPromoVariationCount()).to.equal(0);
+            expect(fragment.listLocaleVariations()).to.have.lengthOf(0);
+            expect(fragment.getTotalVariationCount()).to.equal(0);
         });
     });
 

--- a/studio/test/aem/fragment.test.js
+++ b/studio/test/aem/fragment.test.js
@@ -522,4 +522,33 @@ describe('Fragment', () => {
             expect(store.value.getFieldValues('title')).to.deep.equal([]);
         });
     });
+    describe('getCurrentTagTitle (product_code / Tag Path)', () => {
+        it('uses product_code title alone when only the product_code segment is present, and adds PAC when a nested PA segment exists', () => {
+            const productCodeOnly = new Fragment(
+                createFragmentConfig({
+                    tags: [{ id: 'mas:product_code/cc', title: 'CC Parent' }],
+                    fields: [{ name: 'tags', values: ['mas:product_code/cc'], multiple: true }],
+                }),
+            );
+            expect(productCodeOnly.getCurrentTagTitle('mas:product_code/')).to.equal('CC Parent');
+
+            const withNestedPa = new Fragment(
+                createFragmentConfig({
+                    tags: [{ id: 'mas:product_code/cc/frameio', title: 'Frame.io Plus' }],
+                    fields: [{ name: 'tags', values: ['mas:product_code/cc/frameio'], multiple: true }],
+                }),
+            );
+            expect(withNestedPa.getCurrentTagTitle('mas:product_code/')).to.equal('Frame.io Plus (FRAMEIO)');
+        });
+
+        it('falls back to prettified segment when no tag title is available', () => {
+            const fragment = new Fragment(
+                createFragmentConfig({
+                    tags: [],
+                    fields: [{ name: 'tags', values: ['mas:product_code/my_custom_code'], multiple: true }],
+                }),
+            );
+            expect(fragment.getCurrentTagTitle('mas:product_code/')).to.equal('My Custom Code');
+        });
+    });
 });

--- a/studio/test/aem/mas-filter-panel.test.html
+++ b/studio/test/aem/mas-filter-panel.test.html
@@ -265,6 +265,50 @@
                         expect(filterPanel.tagsByType.pzn).to.have.lengthOf(1);
                         expect(filterPanel.tagsByType.pzn[0].path).to.equal('/content/cq:tags/mas/pzn/general');
                     });
+
+                    it('collapses nested product_code URL tag to parent path for filter chips', async function () {
+                        Store.filters.set({
+                            tags: 'mas:product_code/apptype/mypac',
+                        });
+
+                        const filterPanel = initElementFromTemplate('filterPanel1', this.test.title);
+                        await filterPanel.updateComplete;
+
+                        expect(filterPanel.tagsByType.product_code).to.have.lengthOf(1);
+                        const chip = filterPanel.tagsByType.product_code[0];
+                        expect(chip.path).to.equal('/content/cq:tags/mas/product_code/apptype');
+                        expect(chip.title).to.equal('APPTYPE');
+                        expect(chip.top).to.equal('product_code');
+                    });
+
+                    it('does not duplicate product_code when the same nested tag appears twice in URL', async function () {
+                        Store.filters.set({
+                            tags: 'mas:product_code/apptype/mypac,mas:product_code/apptype/mypac',
+                        });
+
+                        const filterPanel = initElementFromTemplate('filterPanel1', this.test.title);
+                        await filterPanel.updateComplete;
+
+                        expect(filterPanel.tagsByType.product_code).to.have.lengthOf(1);
+                    });
+
+                    it('expands parent-only product_code selection to leaf tags in store filters', async function () {
+                        const filterPanel = initElementFromTemplate('filterPanel1', this.test.title);
+                        await filterPanel.updateComplete;
+
+                        const productCodePicker = filterPanel.shadowRoot.querySelector(
+                            'aem-tag-picker-field[top="product_code"]',
+                        );
+                        expect(productCodePicker).to.not.be.null;
+                        await productCodePicker.loadTags();
+                        await productCodePicker.updateComplete;
+
+                        await productCodePicker.toggleTag('/content/cq:tags/mas/product_code/apptype');
+                        await filterPanel.updateComplete;
+
+                        const tagsParam = Store.filters.get().tags || '';
+                        expect(tagsParam).to.include('mas:product_code/apptype/mypac');
+                    });
                 });
             });
         </script>

--- a/studio/test/editors/merch-card-editor.test.html
+++ b/studio/test/editors/merch-card-editor.test.html
@@ -294,7 +294,8 @@
                         const [, rootPath, sourceLocale, fragmentPath] =
                             sourceFragment.path.match(/^(\/content\/dam\/mas\/[^/]+)\/([^/]+)\/(.+)$/) || [];
 
-                        const localeCodes = ['en_AU', 'fr_FR', 'de_DE', 'es_ES', 'it_IT'];
+                        // Locales in the same default-locale family as en_US on ACOM/nala (see getRegionLocales + isVariationPathInParentLocaleFamily)
+                        const localeCodes = ['en_CA', 'en_AE', 'en_BE', 'en_NZ', 'en_SG', 'en_IE', 'en_PH'];
                         const variationPaths = [];
                         const references = [];
 
@@ -669,7 +670,7 @@
                             promo: 0,
                             grouped: 2,
                             includeReferences: true,
-                            includeCurrentGroupedPath: true,
+                            includeCurrentGroupedPath: false,
                         });
 
                         const source = fragmentEditor.localeDefaultFragment;

--- a/studio/test/mocks/tags.json
+++ b/studio/test/mocks/tags.json
@@ -612,6 +612,18 @@
             "excerpt": "",
             "name": "edu",
             "title": "EDU"
+        },
+        {
+            "path": "/content/cq:tags/mas/product_code/apptype",
+            "excerpt": "",
+            "name": "apptype",
+            "title": "App Type"
+        },
+        {
+            "path": "/content/cq:tags/mas/product_code/apptype/mypac",
+            "excerpt": "",
+            "name": "mypac",
+            "title": "My PAC"
         }
     ]
 }


### PR DESCRIPTION
Brings 3 upstream commits into mas-pinata/main:

- MWPW-192698 — Lower batchSize and add rps limit to reduce concurrent requests to Odin (#764)
- MWPW-190609 — Show fragment variations for selected locale only (#725)
- MWPW-189008 — Update data path to use 'Product Code' (#716)

Routine upstream sync. No pinata-specific files modified.

## Test plan
- [ ] CI passes on PR
- [ ] Verify pinata workflow files unchanged in diff
- [ ] Verify .pinata.config.json unchanged