### PR TITLE
chore(pinata): mark mas as IMS-gated for harness reviewer

### DIFF
--- a/.pinata/.config.json
+++ b/.pinata/.config.json
@@ -54,6 +54,7 @@
     },
     "review": {
         "start_recipe": "pinata-start",
-        "stop_recipe": "pinata-stop"
+        "stop_recipe": "pinata-stop",
+        "ims_gated": true
     }
 }


### PR DESCRIPTION
## Summary

Adds `"ims_gated": true` to the `review` block in `.pinata/.config.json`. This is a harness-meta config flag — read by Adobe-acom/pinata's `workflows/review.py` at review time. **No change to runtime app behaviour.**

## Why

`mas-studio` IMS clientId has its redirect_uri allow-list registered in IMS prod for `*.aem.live` and `https://www.adobe.com/mas/studio.html`, **not** `http://localhost`. When the harness reviewer opens `http://localhost:<port>/studio.html` to capture screenshots, IMS silently substitutes the redirect_uri to `www.adobe.com`, the post-auth browser lands there with the access token in origin-scoped localStorage (invisible to localhost), and re-navigating triggers an infinite signIn loop. Every Studio PR has been silently capturing zero screenshots.

This flag opts `apps/mas` into the harness's new IMS-gated screenshot path: the reviewer targets the deployed `*.aem.live` preview origin (already in the IMS allow-list) instead of localhost. Mirrors Nala's existing strategy (`playwright.config.js:44` + `nala/libs/auth.setup.cjs`).

## Cross-repo coupling

Companion PR in the harness: **Adobe-acom/pinata#135** (which adds the `workflows/review.py` + `.claude/commands/reviewing.md` logic that reads this flag). Both must land for the fix to take effect — full RCA in `Adobe-acom/pinata#132`.

## Test plan

- [x] JSON validates
- [ ] After Adobe-acom/pinata#135 also merges, run a Studio PR through the harness end-to-end and confirm the reviewer captures non-empty screenshots on the *.aem.live origin.