### PR TITLE
feat(clone): label-triggered fork→upstream PR clone

### DIFF
--- a/.github/workflows/clone-to-upstream.yml
+++ b/.github/workflows/clone-to-upstream.yml
@@ -1,0 +1,61 @@
+name: 'Clone to Upstream'
+
+on:
+    pull_request:
+        types: [labeled]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    clone:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout fork (full history)
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  fetch-depth: 0
+
+            - name: Mint token for harness checkout
+              id: harness-token
+              uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+              with:
+                  app-id: ${{ secrets.PINATA_APP_ID }}
+                  private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+                  owner: adobe-acom
+                  repositories: pinata
+
+            - name: Checkout harness scripts
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  repository: adobe-acom/pinata
+                  ref: main
+                  path: .pinata-harness
+                  token: ${{ steps.harness-token.outputs.token }}
+
+            - name: Mint clone token (mas-pinata + mas)
+              id: clone-token
+              uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+              with:
+                  app-id: ${{ secrets.PINATA_APP_ID }}
+                  private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+                  owner: adobecom
+                  repositories: |
+                      mas-pinata
+                      mas
+
+            - name: Set up uv
+              uses: astral-sh/setup-uv@v6
+
+            - name: Run clone
+              env:
+                  APP_TOKEN: ${{ steps.clone-token.outputs.token }}
+                  GITHUB_EVENT_PATH: ${{ github.event_path }}
+              run: |
+                  uv run .pinata-harness/workflows/clone_to_upstream.py \
+                      --pr=${{ github.event.pull_request.number }} \
+                      --fork-repo=${{ github.repository }} \
+                      --label="${{ github.event.label.name }}" \
+                      --repo-path=.

--- a/.github/workflows/clone-to-upstream.yml
+++ b/.github/workflows/clone-to-upstream.yml
@@ -47,6 +47,10 @@ jobs:
 
             - name: Mint clone token (mas-pinata + mas)
               id: clone-token
+              # Don't fail-fast — surface a clear PR comment if the App
+              # isn't installed on the upstream repo (else the dev sees
+              # only a 422 stack trace in the Actions log).
+              continue-on-error: true
               uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
               with:
                   app-id: ${{ secrets.PINATA_APP_ID }}
@@ -55,6 +59,26 @@ jobs:
                   repositories: |
                       mas-pinata
                       mas
+
+            - name: Mint tenant-only token for failure comment
+              if: steps.clone-token.outcome == 'failure'
+              id: tenant-token
+              uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+              with:
+                  app-id: ${{ secrets.PINATA_APP_ID }}
+                  private-key: ${{ secrets.PINATA_APP_PRIVATE_KEY }}
+                  owner: adobecom
+                  repositories: mas-pinata
+
+            - name: Comment on source PR if upstream install missing
+              if: steps.clone-token.outcome == 'failure'
+              env:
+                  GH_TOKEN: ${{ steps.tenant-token.outputs.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "❌ Clone aborted: the \`pinata-agent\` App does not have access to all repositories in this workflow's clone scope. An admin must extend the App's access in the \`adobecom\` org settings to include the configured upstream repo (see \`.pinata/.config.json::clone.upstream_repo\`). Once installed, re-apply the label."
+                  exit 1
 
             - name: Set up uv
               uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.0.1

--- a/.github/workflows/clone-to-upstream.yml
+++ b/.github/workflows/clone-to-upstream.yml
@@ -6,10 +6,20 @@ on:
 
 permissions:
     contents: read
-    pull-requests: read
+
+# Don't race two runs against the same upstream branch when a PR is rapidly
+# unlabeled/relabeled. Cancel-in-progress is false because we don't want to
+# leave the upstream branch half-pushed if a second event arrives mid-flight.
+concurrency:
+    group: clone-to-upstream-${{ github.event.pull_request.number }}
+    cancel-in-progress: false
 
 jobs:
     clone:
+        # Skip PRs whose head branch lives in a fork — secrets are stripped
+        # for those events and the head SHA isn't fetchable from `origin`.
+        # Direct branch PRs only.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -47,15 +57,17 @@ jobs:
                       mas
 
             - name: Set up uv
-              uses: astral-sh/setup-uv@v6
+              uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.0.1
 
             - name: Run clone
               env:
                   APP_TOKEN: ${{ steps.clone-token.outputs.token }}
-                  GITHUB_EVENT_PATH: ${{ github.event_path }}
+                  LABEL_NAME: ${{ github.event.label.name }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  FORK_REPO: ${{ github.repository }}
               run: |
                   uv run .pinata-harness/workflows/clone_to_upstream.py \
-                      --pr=${{ github.event.pull_request.number }} \
-                      --fork-repo=${{ github.repository }} \
-                      --label="${{ github.event.label.name }}" \
+                      --pr="$PR_NUMBER" \
+                      --fork-repo="$FORK_REPO" \
+                      --label="$LABEL_NAME" \
                       --repo-path=.

--- a/.pinata/.config.json
+++ b/.pinata/.config.json
@@ -52,6 +52,14 @@
             "exit_nonzero": false
         }
     },
+    "clone": {
+        "label": "clone-to-mas",
+        "upstream_repo": "adobecom/mas",
+        "pinata_paths": [
+            ".github/workflows/pinata*.yml",
+            ".pinata/**"
+        ]
+    },
     "review": {
         "start_recipe": "pinata-start",
         "stop_recipe": "pinata-stop"


### PR DESCRIPTION
## Summary

Adds the tenant side of a label-triggered fork→upstream PR clone. When the `clone-to-mas` label is applied to an open PR here, a workflow mints a `pinata-agent[bot]` install token, computes the source PR's diff (filtered to remove pinata-only paths), and opens a clean equivalent PR in `adobecom/mas` with the source author preserved in `git blame`.

## Changes

- **`.github/workflows/clone-to-upstream.yml`** — workflow on `pull_request: [labeled]`. Mints two App tokens (harness checkout + cross-repo push), invokes the harness `clone_to_upstream.py` script.
  - `if:` guard skips PRs whose head branch lives in an external fork (secrets stripped, head SHA not fetchable).
  - `concurrency:` block on PR number prevents races on rapid relabel.
  - All actions SHA-pinned. Label/PR/repo names passed via env vars (defense in depth against shell injection through label name).
- **`.pinata/.config.json`** — adds `clone` block:
  - `label`: `clone-to-mas`
  - `upstream_repo`: `adobecom/mas`
  - `pinata_paths`: `[".github/workflows/pinata*.yml", ".pinata/**"]` (filtered out of the upstream diff)

## Dependency: harness PR

This workflow checks out `adobe-acom/pinata:main` for the harness scripts. **Do not merge until that's landed:**

- Harness PR: https://github.com/Adobe-acom/pinata/pull/175
- Order: merge harness → wait for `stage`→`main` promotion → merge this.

## Admin prereqs

- `pinata-agent` App installed on `adobecom/mas` (`contents:write`, `pull_requests:write`).
- `pinata-agent` App installed on `adobe-acom/pinata` (`contents:read`).
- Repository secrets `PINATA_APP_ID`, `PINATA_APP_PRIVATE_KEY` already exist in this repo from `pinata.yml`.

## How it behaves

1. Dev applies `clone-to-mas` label.
2. Workflow runs → harness script reads `.pinata/.config.json::clone`.
3. Diff vs upstream's `main` merge-base, pinata paths stripped.
4. Pushes to `adobecom/mas` with same branch name.
5. Opens PR; commit author = original PR author.
6. Comments `✅ Cloned clone PR <url>` back on this PR.

Re-applying the label is idempotent (force-with-lease, only on bot-owned branches). External-contributor PRs are silently skipped (documented constraint).

## Test plan

- [ ] After merge + harness merge, run smoke test from runbook: open throwaway PR, label, verify clone PR appears in `adobecom/mas`, verify commit author preserved, verify idempotent re-label.