### PR TITLE
test: tenant-mental-models smoke test (do not merge)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,5 @@ One of the maintainers will look at the pull request within one week. Feedback o
 
 The project's committers will release to the [Adobe organization on npmjs.org](https://www.npmjs.com/org/adobe).
 Please contact the [Adobe Open Source Advisory Board](https://git.corp.adobe.com/OpenSourceAdvisoryBoard/discuss/issues) to get access to the npmjs organization.
+
+<!-- TODO: add input validation -->


### PR DESCRIPTION
## What

Smoke test for the tenant-mental-models feature merged in [Adobe-acom/pinata#184](https://github.com/Adobe-acom/pinata/pull/184).

This PR adds a synthetic `reviewer.domains[]` block on the base branch and a small code change on the head branch, so the bot's review picks up the tenant config and exercises the tenant flow end-to-end on a real tenant repo.

## URL for testing

- https://test-tms-head--mas-pinata--adobecom.aem.page/

## Verification

The bot's review should produce:

- `📖 Reviewed:` footer naming `mas-pinata-workspace` alongside the existing harness-bundled domains (`mas-nala`, `mas-studio`, `mas-web-components`, `mas-cicd`).
- At least one inline finding citing a synthetic tenant pattern or antipattern.
- No `⚠️ Tenant config rejected` line.
- No `⚠️ shadowed by harness` line.

## Cleanup

Close after verification — both branches throwaway. The mas-pinata team will land their permanent `reviewer.domains[]` configuration in a separate, properly-reviewed PR after this smoke test confirms the wiring.
