### PR TITLE
config: add mental_models block (Piñata tool-shelf migration)

### DIFF
--- a/.pinata/.config.json
+++ b/.pinata/.config.json
@@ -57,5 +57,14 @@
     "review": {
         "start_recipe": "pinata-start",
         "stop_recipe": "pinata-stop"
+    },
+    "mental_models": {
+        "domains": ["mas-nala"],
+        "path_overrides": [
+            { "pattern": ".github/workflows/", "domains": ["mas-cicd"] },
+            { "pattern": "nala/",              "domains": ["mas-nala"] },
+            { "pattern": "studio/",            "domains": ["mas-studio", "mas-nala"] },
+            { "pattern": "web-components/",    "domains": ["mas-web-components", "mas-nala"] }
+        ]
     }
 }


### PR DESCRIPTION
## Summary

Adds a `mental_models` routing block to `.pinata/.config.json`. Once the matching harness migration ships in `Adobe-acom/pinata`, mental-model routing for this repo's PR reviews will be sourced from this file's `mental_models` block instead of the harness's central `config/repo-domains.yaml`.

The values are a verbatim translation of the existing `repos.adobecom/mas-pinata` row in `Adobe-acom/pinata`'s `config/repo-domains.yaml` — no behavior change.

## Background

`Adobe-acom/pinata` is moving mental-model archetypes (the `expertise.yaml` files that `/app:pinata:review` and `/app:pinata:respond` use) into a private shared repo `Adobe-acom/pinata-tool-shelf`. As part of that migration, per-repo routing (which mental-model domains apply to which file paths) is moving out of the central `config/repo-domains.yaml` and into each tenant's own `.pinata/.config.json` `mental_models` block.

This PR is the `mas-pinata` half of that handoff.

## What changed

```diff
+    "mental_models": {
+        "domains": ["mas-nala"],
+        "path_overrides": [
+            { "pattern": ".github/workflows/", "domains": ["mas-cicd"] },
+            { "pattern": "nala/",              "domains": ["mas-nala"] },
+            { "pattern": "studio/",            "domains": ["mas-studio", "mas-nala"] },
+            { "pattern": "web-components/",    "domains": ["mas-web-components", "mas-nala"] }
+        ]
+    }
```

Same shape, same semantics, same domain names as the YAML row today.

## Test plan

- [x] Validates against the harness's `config/schemas/pinata-app-config.schema.json`
- [x] Parity-verified against `repos.adobecom/mas-pinata` in the harness's `config/repo-domains.yaml`
- [ ] After the harness PR (`pnt/tool-shelf-spec`) merges and `repo-domains.yaml` is removed, a Piñata Code Review on this repo will read from this `mental_models` block