### PR TITLE
config: add mental_models block (Piñata tool-shelf migration)

### DIFF
--- a/.pinata/.config.json
+++ b/.pinata/.config.json
@@ -57,5 +57,15 @@
     "review": {
         "start_recipe": "pinata-start",
         "stop_recipe": "pinata-stop"
+    },
+    "mental_models": {
+        "domains": ["mas-nala", "mas-steering", "mas-lead-architect"],
+        "path_overrides": [
+            { "pattern": ".github/workflows/", "domains": ["mas-cicd"] },
+            { "pattern": "nala/", "domains": ["mas-nala"] },
+            { "pattern": "io/", "domains": ["mas-io"] },
+            { "pattern": "studio/", "domains": ["mas-studio", "mas-nala"] },
+            { "pattern": "web-components/", "domains": ["mas-web-components", "mas-nala"] }
+        ]
     }
 }


### PR DESCRIPTION
## Summary

Declares the mental-model domains Piñata loads for this repo in `.pinata/.config.json`, replacing the central `config/repo-domains.yaml` row that the harness is retiring in [Adobe-acom/pinata#192](https://github.com/Adobe-acom/pinata/pull/192). Re-lands #349, which was closed when the harness-side migration was rescoped.

## What's declared

- **Path overrides** (drive two-tier PR review bucketing) — mirrors the old `repo-domains.yaml` row for this repo, plus a new `io/` → `mas-io` entry:
  | pattern | domains |
  |---|---|
  | `.github/workflows/` | mas-cicd |
  | `nala/` | mas-nala |
  | `io/` | mas-io |
  | `studio/` | mas-studio, mas-nala |
  | `web-components/` | mas-web-components, mas-nala |
- **Top-level domains**: `mas-nala`, `mas-steering`, `mas-lead-architect` — the latter two so the Slack respond flow keeps the same 7-domain union it previously derived from the `adobecom/mas` row (it now unions this block instead).

## Notes

- Validated against the harness's `config/schemas/pinata-app-config.schema.json`.
- Merge in coordination with [Adobe-acom/pinata#192](https://github.com/Adobe-acom/pinata/pull/192) — before #192, this block is inert; after #192, repos without a block get baseline-only review.
- Each declared domain resolves to an archetype on `Adobe-acom/pinata-tool-shelf` `mental-models/<domain>/` at CI run time.

## Test URLs

Config-only change (`.pinata/.config.json`) — no page or rendering impact. Preview equivalent to main:
URL for testing:

- https://config-add-mental-models--mas-pinata--adobecom.aem.page/
