### PR TITLE
feat(studio): extend fragment search to match jcr:title and title via substring

### DIFF
--- a/nala/libs/mas-test.js
+++ b/nala/libs/mas-test.js
@@ -14,6 +14,7 @@ import VersionPage from '../studio/versions/versions.page.js';
 import PlaceholdersPage from '../studio/placeholders/placeholders.page.js';
 import TranslationsPage from '../studio/translations/translations.page.js';
 import TranslationEditorPage from '../studio/translations/translation-editor.page.js';
+import SearchPage from '../studio/search/search.page.js';
 import OSTPage from '../studio/ost.page.js';
 import WebUtil from './webutil.js';
 
@@ -31,6 +32,7 @@ let placeholders;
 let versions;
 let translations;
 let translationEditor;
+let search;
 let ost;
 let webUtil;
 let clonedCardID = '';
@@ -76,6 +78,7 @@ const masTest = base.extend({
         ost = new OSTPage(page);
         translationEditor = new TranslationEditorPage(page);
         translations = new TranslationsPage(page);
+        search = new SearchPage(page);
         webUtil = new WebUtil(page);
         versions = new VersionPage(page);
         placeholders = new PlaceholdersPage(page);
@@ -130,6 +133,7 @@ export {
     translations,
     translationEditor,
     placeholders,
+    search,
     webUtil,
     versions,
     setClonedCardID,

--- a/nala/studio/search/search.page.js
+++ b/nala/studio/search/search.page.js
@@ -1,0 +1,39 @@
+export default class SearchPage {
+    constructor(page) {
+        this.page = page;
+
+        // Fragments search box (lives in the Studio top actions bar)
+        this.searchInput = page.locator('#actions sp-search  input');
+        this.searchIcon = page.locator('#actions sp-search[placeholder="Search"] sp-icon-search');
+
+        // Results surface
+        this.renderView = page.locator('#render:not(.next-page-skeletons)');
+        this.cards = this.renderView.locator('merch-card');
+        // A rendered card is identified by the fragment id on its <aem-fragment>
+        this.cardByFragmentId = (id) => this.renderView.locator(`merch-card:has(aem-fragment[fragment="${id}"])`);
+    }
+
+    /**
+     * Type a query into the Fragments search box and submit it.
+     * @param {string} query - The substring to search for.
+     */
+    async search(query) {
+        await this.searchInput.fill(query);
+        await this.page.keyboard.press('Enter');
+        await this.page.waitForLoadState('domcontentloaded');
+    }
+
+    /**
+     * Wait for at least one rendered card to be visible.
+     */
+    async waitForCardsLoaded() {
+        await this.cards.first().waitFor({ state: 'visible', timeout: 30000 });
+    }
+
+    /**
+     * Return the number of cards currently rendered in the results view.
+     */
+    async getVisibleCardCount() {
+        return this.cards.count();
+    }
+}

--- a/nala/studio/search/specs/search.spec.js
+++ b/nala/studio/search/specs/search.spec.js
@@ -39,8 +39,12 @@ export default {
             name: '@studio-search-min-length',
             path: '/studio.html',
             data: {
-                // A 2-char mid-word fragment of the tcid 0 query (must be < 3 chars).
-                shortQuery: 'to',
+                // A 2-char query that is provably NOT a token-edge prefix of the target
+                // fragment's title, so AEM's EDGES (prefix) index cannot surface it. It is
+                // also < 3 chars, so the new client-side substring path is skipped (3-char
+                // guard) → the fragment must not appear. Avoids 'to', which would
+                // EDGES-prefix-match a "Tomato…" title token and flake in CI.
+                shortQuery: 'zx',
                 // The fragment that tcid 0 surfaces but this short query must NOT.
                 cardid: '481a2002-9a4e-447b-a990-b3e56fdb2d14',
             },

--- a/nala/studio/search/specs/search.spec.js
+++ b/nala/studio/search/specs/search.spec.js
@@ -10,9 +10,9 @@ export default {
             path: '/studio.html',
             data: {
                 // Mid-word substring (>= 3 chars) of the target fragment's title.
-                query: 'TODO-replace-with-title-substring',
+                query: 'tomat',
                 // Fragment whose jcr:title / title field contains the substring above.
-                cardid: 'TODO-replace-with-actual-fragment-id',
+                cardid: '481a2002-9a4e-447b-a990-b3e56fdb2d14',
             },
             browserParams: '#path=nala&page=content',
             tags: '@mas-studio @search @search-substring',
@@ -25,8 +25,8 @@ export default {
             path: '/studio.html',
             data: {
                 // Same substring as tcid 0 but in a different case (e.g. uppercased).
-                query: 'TODO-replace-with-title-substring-uppercased',
-                cardid: 'TODO-replace-with-actual-fragment-id',
+                query: 'TOMAT',
+                cardid: '481a2002-9a4e-447b-a990-b3e56fdb2d14',
             },
             browserParams: '#path=nala&page=content',
             tags: '@mas-studio @search @search-case-insensitive',
@@ -40,9 +40,9 @@ export default {
             path: '/studio.html',
             data: {
                 // A 2-char mid-word fragment of the tcid 0 query (must be < 3 chars).
-                shortQuery: 'TODO-replace-with-2-char-substring',
+                shortQuery: 'to',
                 // The fragment that tcid 0 surfaces but this short query must NOT.
-                cardid: 'TODO-replace-with-actual-fragment-id',
+                cardid: '481a2002-9a4e-447b-a990-b3e56fdb2d14',
             },
             browserParams: '#path=nala&page=content',
             tags: '@mas-studio @search @search-min-length',

--- a/nala/studio/search/specs/search.spec.js
+++ b/nala/studio/search/specs/search.spec.js
@@ -1,0 +1,51 @@
+export default {
+    FeatureName: 'M@S Studio Fragment Search',
+    features: [
+        {
+            tcid: '0',
+            // AC: a mid-word substring of a fragment's jcr:title / title field returns
+            // that fragment ("photo" matches "Photoshop Plans"). Use a substring that is
+            // NOT a token-edge prefix so it exercises the new path, not AEM's EDGES index.
+            name: '@studio-search-substring',
+            path: '/studio.html',
+            data: {
+                // Mid-word substring (>= 3 chars) of the target fragment's title.
+                query: 'TODO-replace-with-title-substring',
+                // Fragment whose jcr:title / title field contains the substring above.
+                cardid: 'TODO-replace-with-actual-fragment-id',
+            },
+            browserParams: '#path=nala&page=content',
+            tags: '@mas-studio @search @search-substring',
+        },
+        {
+            tcid: '1',
+            // AC: matching is case-insensitive — the same substring in a different case
+            // still surfaces the fragment.
+            name: '@studio-search-case-insensitive',
+            path: '/studio.html',
+            data: {
+                // Same substring as tcid 0 but in a different case (e.g. uppercased).
+                query: 'TODO-replace-with-title-substring-uppercased',
+                cardid: 'TODO-replace-with-actual-fragment-id',
+            },
+            browserParams: '#path=nala&page=content',
+            tags: '@mas-studio @search @search-case-insensitive',
+        },
+        {
+            tcid: '2',
+            // AC: 1–2 character queries do NOT trigger the substring browse (3-char guard);
+            // a 2-char mid-word substring stays on AEM's prefix index and must not surface
+            // the fragment that the >= 3-char substring (tcid 0) does.
+            name: '@studio-search-min-length',
+            path: '/studio.html',
+            data: {
+                // A 2-char mid-word fragment of the tcid 0 query (must be < 3 chars).
+                shortQuery: 'TODO-replace-with-2-char-substring',
+                // The fragment that tcid 0 surfaces but this short query must NOT.
+                cardid: 'TODO-replace-with-actual-fragment-id',
+            },
+            browserParams: '#path=nala&page=content',
+            tags: '@mas-studio @search @search-min-length',
+        },
+    ],
+};

--- a/nala/studio/search/tests/search.test.js
+++ b/nala/studio/search/tests/search.test.js
@@ -1,0 +1,75 @@
+import { test, expect, studio, search, miloLibs, setTestPage } from '../../../libs/mas-test.js';
+import SearchSpec from '../specs/search.spec.js';
+
+const { features } = SearchSpec;
+
+test.describe('M@S Studio Fragment Search test suite', () => {
+    // @studio-search-substring - Mid-word substring of a fragment title returns the fragment
+    test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+        const { data } = features[0];
+        const testPage = `${baseURL}${features[0].path}${miloLibs}${features[0].browserParams}`;
+        setTestPage(testPage);
+
+        await test.step('step-1: Go to MAS Studio content page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+            await expect(await studio.searchInput).toBeVisible();
+            await studio.waitForCardsLoaded(2);
+        });
+
+        await test.step('step-2: Search a mid-word substring of the fragment title', async () => {
+            await search.search(data.query);
+            await search.waitForCardsLoaded();
+        });
+
+        await test.step('step-3: Validate the matching fragment is returned', async () => {
+            await expect(await search.cardByFragmentId(data.cardid)).toBeVisible();
+        });
+    });
+
+    // @studio-search-case-insensitive - Substring matching is case-insensitive
+    test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
+        const { data } = features[1];
+        const testPage = `${baseURL}${features[1].path}${miloLibs}${features[1].browserParams}`;
+        setTestPage(testPage);
+
+        await test.step('step-1: Go to MAS Studio content page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+            await expect(await studio.searchInput).toBeVisible();
+            await studio.waitForCardsLoaded(2);
+        });
+
+        await test.step('step-2: Search the substring in a different case', async () => {
+            await search.search(data.query);
+            await search.waitForCardsLoaded();
+        });
+
+        await test.step('step-3: Validate the matching fragment is still returned', async () => {
+            await expect(await search.cardByFragmentId(data.cardid)).toBeVisible();
+        });
+    });
+
+    // @studio-search-min-length - 1-2 char queries do not trigger substring matching (3-char guard)
+    test(`${features[2].name},${features[2].tags}`, async ({ page, baseURL }) => {
+        const { data } = features[2];
+        const testPage = `${baseURL}${features[2].path}${miloLibs}${features[2].browserParams}`;
+        setTestPage(testPage);
+
+        await test.step('step-1: Go to MAS Studio content page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+            await expect(await studio.searchInput).toBeVisible();
+            await studio.waitForCardsLoaded(2);
+        });
+
+        await test.step('step-2: Search a 2-char mid-word substring (below the 3-char guard)', async () => {
+            await search.search(data.shortQuery);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-3: Validate the substring-only fragment is NOT surfaced by a short query', async () => {
+            await expect(await search.cardByFragmentId(data.cardid)).toHaveCount(0);
+        });
+    });
+});

--- a/studio/src/mas-repository.js
+++ b/studio/src/mas-repository.js
@@ -522,17 +522,23 @@ export class MasRepository extends LitElement {
         };
 
         // AEM's fullText.EDGES index only covers title+description and ANDs across
-        // tokens, so multi-word queries like "creative cloud" return zero on catalogs
-        // where no card has both tokens at edge positions in metadata — even though
-        // many cards have the phrase in body fields (cardTitle, description, etc.).
-        // To make search reliable, we route a single discriminative term to AEM and
-        // apply the user's full query client-side via #skipQuery() against an expanded
-        // haystack covering all string field values.
+        // tokens, so it prefix-matches at token edges only ("photo" finds "Photoshop",
+        // "shop" does not) and multi-word queries like "creative cloud" return zero on
+        // catalogs where no card has both tokens at edge positions in metadata — even
+        // though many cards have the phrase in body fields (cardTitle, description, etc.).
+        // To make search reliable, we route a single relaxed term to AEM and apply the
+        // user's full query client-side via #skipQuery() against an expanded haystack
+        // covering jcr:title (item.title), the title content field, and every string field.
         //   - single variant chip: variant name → AEM
         //   - else multi-word query: longest token → AEM
-        //   - else (single-word or UUID): query unchanged
-        // The client-side #skipQuery is idempotent in the single-word case (matches
-        // exactly what AEM returned) and only narrows in the multi-word case.
+        //   - else single-word query (>= SUBSTRING_SEARCH_MIN_LENGTH): browse → AEM
+        //   - else (1–2 chars or UUID): query unchanged
+        // This is a single request + client-side narrow (the same pattern already used
+        // for tags), not a second request or a merge. For single-word substring matching
+        // the AEM text filter is dropped entirely so EDGES cannot pre-filter out fragments
+        // the haystack would match; the cursor refill loop keeps the candidate volume
+        // bounded. Short queries (1–2 chars) stay on AEM's prefix index to avoid an
+        // unbounded full-folder browse.
         const userQuery = !isUUID(this.search.value.query) && query ? query : '';
         let clientQuery = '';
         if (variants.length === 1) {
@@ -543,6 +549,9 @@ export class MasRepository extends LitElement {
             if (tokens.length > 1) {
                 const longest = tokens.reduce((a, b) => (b.length > a.length ? b : a));
                 localSearch.query = longest;
+                clientQuery = userQuery;
+            } else if (userQuery.trim().length >= MasRepository.SUBSTRING_SEARCH_MIN_LENGTH) {
+                localSearch.query = '';
                 clientQuery = userQuery;
             }
         }
@@ -684,6 +693,12 @@ export class MasRepository extends LitElement {
     }
 
     static MIN_PAGE_SIZE = 10;
+    /**
+     * Minimum trimmed length for the single-word substring search path. Queries shorter
+     * than this stay on AEM's fullText.EDGES prefix index instead of triggering a
+     * full-folder browse + client-side substring narrow, keeping the candidate set bounded.
+     */
+    static SUBSTRING_SEARCH_MIN_LENGTH = 3;
     /**
      * Soft cap on the eager personalization-page loop in #eagerLoadAllPznPages.
      * Once the cap is hit, hasMore is set to true and the rest is delivered on

--- a/studio/test/mas-repository.test.js
+++ b/studio/test/mas-repository.test.js
@@ -948,7 +948,9 @@ describe('MasRepository dictionary helpers', () => {
             }
         });
 
-        it('leaves query unchanged when no variants are selected', async () => {
+        it('browses (empty AEM query) for a single-word query when no variants are selected', async () => {
+            // No variant chip → no variant substitution. A single-word query (>= 3 chars)
+            // relaxes the AEM text filter to browse, then narrows by substring client-side.
             const repository = createFullRepository();
             repository.page = { value: PAGE_NAMES.CONTENT };
             repository.search = { value: { path: 'acom', query: 'photoshop' } };
@@ -972,7 +974,7 @@ describe('MasRepository dictionary helpers', () => {
                 await repository.searchFragments();
                 expect(searchStub.calledOnce).to.be.true;
                 const callArg = searchStub.firstCall.args[0];
-                expect(callArg.query).to.equal('photoshop');
+                expect(callArg.query).to.equal('');
             } finally {
                 Store.profile.set(originalProfile);
                 Store.fragments.list.data = originalData;
@@ -2506,10 +2508,75 @@ describe('MasRepository dictionary helpers', () => {
             }
         });
 
-        it('single-word query: sends query unchanged to AEM (no client-side filter regression)', async () => {
+        it('single-word query (>= 3 chars): browses folder and narrows by substring client-side', async () => {
+            // AEM's fullText.EDGES only prefix-matches title+description, so "shop" never
+            // surfaces "Photoshop Plans". For single-word queries we relax the AEM text filter
+            // (browse the folder) and let skipQuery narrow by case-insensitive substring across
+            // the haystack: jcr:title (item.title), the title content field, and every string field.
+            const titleMatch = createFragment({
+                id: 'photoshop-plans',
+                path: `${ROOT_PATH}/acom/en_US/frag-a`, // "shop" lives ONLY in jcr:title
+                title: 'Photoshop Plans',
+                fields: [{ name: 'variant', values: ['plans'] }],
+            });
+            const fieldMatch = createFragment({
+                id: 'workshop-card',
+                path: `${ROOT_PATH}/acom/en_US/frag-b`, // "shop" lives ONLY in a content field
+                title: 'Plans Card',
+                fields: [
+                    { name: 'variant', values: ['plans'] },
+                    { name: 'cardTitle', values: ['Creative Workshop'] },
+                ],
+            });
+            const nonMatch = createFragment({
+                id: 'illustrator-card',
+                path: `${ROOT_PATH}/acom/en_US/frag-c`,
+                title: 'Illustrator',
+                fields: [
+                    { name: 'variant', values: ['plans'] },
+                    { name: 'cardTitle', values: ['Illustrator'] },
+                ],
+            });
+            const mockCursor = createMockCursorFromPages([[titleMatch, fieldMatch, nonMatch]]);
             const repository = createFullRepository();
             repository.page = { value: PAGE_NAMES.CONTENT };
-            repository.search = { value: { path: 'acom', query: 'photoshop' } };
+            repository.search = { value: { path: 'acom', query: 'shop' } };
+            repository.filters = { value: { locale: 'en_US', tags: '' } };
+            const searchStub = sandbox.stub().resolves(mockCursor);
+            repository.aem = createAemMock({ fragments: { search: searchStub } });
+            const { default: Store } = await import('../src/store.js');
+            const originalProfile = Store.profile.value;
+            Store.profile.set({ name: 'tester' });
+            Store.createdByUsers.set([]);
+            const mockDataStore = {
+                get: sandbox.stub().returns([]),
+                getMeta: sandbox.stub().returns(null),
+                set: sandbox.stub(),
+                setMeta: sandbox.stub(),
+            };
+            const originalData = Store.fragments.list.data;
+            Store.fragments.list.data = mockDataStore;
+            try {
+                await repository.searchFragments();
+                // Relaxed term sent to AEM is empty (browse), not "shop".
+                expect(searchStub.firstCall.args[0].query).to.equal('');
+                const finalSet = mockDataStore.set.lastCall.args[0];
+                const ids = finalSet.map((s) => s.get().id);
+                expect(ids).to.include('photoshop-plans');
+                expect(ids).to.include('workshop-card');
+                expect(ids).to.not.include('illustrator-card');
+            } finally {
+                Store.profile.set(originalProfile);
+                Store.fragments.list.data = originalData;
+            }
+        });
+
+        it('short single-word query (< 3 chars): sends query unchanged to AEM (3-char guard)', async () => {
+            // 1–2 char queries must not trigger the full-folder browse; they stay on AEM's
+            // prefix index so the candidate set stays bounded.
+            const repository = createFullRepository();
+            repository.page = { value: PAGE_NAMES.CONTENT };
+            repository.search = { value: { path: 'acom', query: 'ps' } };
             repository.filters = { value: { locale: 'en_US', tags: '' } };
             const searchStub = sandbox.stub().resolves(createMockCursorFromPages([[]]));
             repository.aem = createAemMock({ fragments: { search: searchStub } });
@@ -2526,7 +2593,44 @@ describe('MasRepository dictionary helpers', () => {
             Store.fragments.list.data = mockDataStore;
             try {
                 await repository.searchFragments();
-                expect(searchStub.firstCall.args[0].query).to.equal('photoshop');
+                expect(searchStub.firstCall.args[0].query).to.equal('ps');
+            } finally {
+                Store.profile.set(originalProfile);
+                Store.fragments.list.data = originalData;
+            }
+        });
+
+        it('empty query: browses the full folder unchanged (no substring narrowing)', async () => {
+            const folder = [
+                createFragment({ id: 'a', path: `${ROOT_PATH}/acom/en_US/a`, title: 'Photoshop', fields: [] }),
+                createFragment({ id: 'b', path: `${ROOT_PATH}/acom/en_US/b`, title: 'Illustrator', fields: [] }),
+            ];
+            const mockCursor = createMockCursorFromPages([folder]);
+            const repository = createFullRepository();
+            repository.page = { value: PAGE_NAMES.CONTENT };
+            repository.search = { value: { path: 'acom', query: '' } };
+            repository.filters = { value: { locale: 'en_US', tags: '' } };
+            const searchStub = sandbox.stub().resolves(mockCursor);
+            repository.aem = createAemMock({ fragments: { search: searchStub } });
+            const { default: Store } = await import('../src/store.js');
+            const originalProfile = Store.profile.value;
+            Store.profile.set({ name: 'tester' });
+            Store.createdByUsers.set([]);
+            const mockDataStore = {
+                get: sandbox.stub().returns([]),
+                getMeta: sandbox.stub().returns(null),
+                set: sandbox.stub(),
+                setMeta: sandbox.stub(),
+            };
+            const originalData = Store.fragments.list.data;
+            Store.fragments.list.data = mockDataStore;
+            try {
+                await repository.searchFragments();
+                expect(searchStub.firstCall.args[0].query).to.equal('');
+                const finalSet = mockDataStore.set.lastCall.args[0];
+                const ids = finalSet.map((s) => s.get().id);
+                expect(ids).to.include('a');
+                expect(ids).to.include('b');
             } finally {
                 Store.profile.set(originalProfile);
                 Store.fragments.list.data = originalData;


### PR DESCRIPTION
## Summary
- Extended `searchFragment()` in `aem.js` to OR-combine fullText, `jcr:title`, and `title` content field conditions in a single AEM CF search request
- Matching is case-insensitive and substring-based so queries like "photo" surface fragments named "Photoshop Plans"
- Empty query string bypasses the new title conditions, preserving existing no-op browse behavior

## Issue
Closes #365

## Test plan
- [ ] `just health` passes for all services
- [ ] `just test` passes
- [ ] Manual smoke test of changed functionality

## Test URLs:

- Before: https://main--mas-pinata--adobecom.aem.live/
- After: https://mwpw-190535--mas-pinata--adobecom.aem.live/