### PR TITLE
feat(studio): extend fragment search to match on jcr:title and title field

### DIFF
--- a/nala/studio/fragment-search/fragment-search.page.js
+++ b/nala/studio/fragment-search/fragment-search.page.js
@@ -1,0 +1,21 @@
+export default class FragmentSearchPage {
+    constructor(page) {
+        this.page = page;
+
+        this.searchInput = page.locator('#actions sp-search input');
+        this.renderView = page.locator('#render');
+        this.cards = this.renderView.locator('merch-card');
+    }
+
+    /** Type a query into the Fragments search box and submit it. */
+    async search(term) {
+        await this.searchInput.fill(term);
+        await this.page.keyboard.press('Enter');
+    }
+
+    /** Clear the search box and submit, restoring the full browse list. */
+    async clearSearch() {
+        await this.searchInput.fill('');
+        await this.page.keyboard.press('Enter');
+    }
+}

--- a/nala/studio/fragment-search/specs/fragment-search.spec.js
+++ b/nala/studio/fragment-search/specs/fragment-search.spec.js
@@ -1,0 +1,24 @@
+export default {
+    FeatureName: 'M@S Studio Fragment Search Title',
+    features: [
+        {
+            tcid: '0',
+            name: '@studio-fragment-search-title',
+            path: '/studio.html',
+            data: {
+                cardid: '48a759ce-3c9a-4158-9bc3-b21ffa07e8e4',
+                searchTerm: 'suggested',
+            },
+            browserParams: '#page=content&path=nala',
+            tags: '@mas-studio @fragment-search @fragment-search-title',
+        },
+        {
+            tcid: '1',
+            name: '@studio-fragment-search-empty-query',
+            path: '/studio.html',
+            data: {},
+            browserParams: '#page=content&path=nala',
+            tags: '@mas-studio @fragment-search @fragment-search-empty',
+        },
+    ],
+};

--- a/nala/studio/fragment-search/tests/fragment-search.test.js
+++ b/nala/studio/fragment-search/tests/fragment-search.test.js
@@ -1,0 +1,53 @@
+import { test, expect, studio, miloLibs, setTestPage } from '../../../libs/mas-test.js';
+import FragmentSearchSpec from '../specs/fragment-search.spec.js';
+
+const { features } = FragmentSearchSpec;
+
+test.describe('Fragment Search Title feature test suite', () => {
+    // @studio-fragment-search-title — Typing a title substring surfaces the matching fragment.
+    // This proves the server-side gap the issue closes: AEM fullText does not index jcr:title,
+    // so a substring of a fragment's title only matches via the extended OR filter.
+    test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+        const { data } = features[0];
+        const testPage = `${baseURL}${features[0].path}${miloLibs}${features[0].browserParams}`;
+        setTestPage(testPage);
+
+        await test.step('step-1: Go to MAS Studio content page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Validate cards are loaded', async () => {
+            await studio.waitForCardsLoaded();
+            const cards = studio.renderView.locator('merch-card');
+            expect(await cards.count()).toBeGreaterThan(1);
+        });
+
+        await test.step('step-3: Search by title substring returns the matching fragment', async () => {
+            await studio.searchInput.fill(data.searchTerm);
+            await page.keyboard.press('Enter');
+            await studio.waitForCardsLoaded();
+
+            const searchResults = studio.renderView.locator('merch-card');
+            expect(await searchResults.count()).toBeGreaterThan(0);
+            await expect(await studio.getCard(data.cardid)).toBeVisible();
+        });
+    });
+
+    // @studio-fragment-search-empty-query — An empty query restores the full browse list.
+    test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
+        const testPage = `${baseURL}${features[1].path}${miloLibs}${features[1].browserParams}`;
+        setTestPage(testPage);
+
+        await test.step('step-1: Go to MAS Studio content page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Validate empty query returns multiple fragments', async () => {
+            await studio.waitForCardsLoaded();
+            const cards = studio.renderView.locator('merch-card');
+            expect(await cards.count()).toBeGreaterThan(1);
+        });
+    });
+});

--- a/studio/src/aem/aem.js
+++ b/studio/src/aem/aem.js
@@ -6,6 +6,9 @@ const MAX_POLL_ATTEMPTS = 10;
 const POLL_TIMEOUT = 250;
 const MAX_NAME_ATTEMPTS = 10;
 const COPY_WAIT_TIME = 1000;
+// Minimum query length before the substring jcr:title/title OR branch is added. Queries of
+// 1–2 chars stay on fullText-only to avoid expensive repository-wide substring scans.
+const MIN_TITLE_QUERY_LENGTH = 3;
 
 const defaultSearchOptions = {
     sort: [{ on: 'created', order: 'ASC' }],
@@ -91,7 +94,11 @@ class AEM {
      * @param {string} [params.path] - The path to search in
      * @param {Array} [params.tags] - The tags
      * @param {Array} [params.modelIds] - The model ids
-     * @param {string} [params.query] - The search query
+     * @param {string} [params.query] - The search query. When it is at least
+     *   {@link MIN_TITLE_QUERY_LENGTH} chars, it is OR-matched against three surfaces in a single
+     *   AEM CF search request: fullText content (EDGES mode), the `jcr:title` metadata property
+     *   (substring/CONTAINS) and the `title` content field (substring/CONTAINS). A 1–2 char query
+     *   falls back to fullText-only, and an empty query is a no-op browse with no text conditions.
      * @param {AbortController} abortController used for cancellation
      * @returns A generator function that fetches all the matching data using a cursor that is returned by the search API
      */
@@ -99,10 +106,33 @@ class AEM {
         const filter = {
             path,
         };
-        if (query) {
+        if (query && query.length >= MIN_TITLE_QUERY_LENGTH) {
+            // Single-request OR composition: AEM's fullText.EDGES index requires the query to
+            // appear at a word edge in indexed content, so substring lookups like "Photo" miss
+            // fragments named "Photoshop Plans". We OR fullText with explicit substring matches
+            // on the jcr:title metadata property and the `title` content field to cover both.
+            // Filter schema: https://adobe-sites.redoc.ly/tag/Search
+            filter.any = [
+                {
+                    fullText: {
+                        text: encodeURIComponent(query),
+                        // For info about modes: https://adobe-sites.redoc.ly/tag/Search#operation/fragments/search!path=query/filter/fullText/queryMode&t=request
+                        queryMode: 'EDGES',
+                    },
+                },
+                {
+                    // Raw query value: URLSearchParams encodes the whole query JSON for transport,
+                    // so a second encodeURIComponent here would double-encode the substring.
+                    properties: [{ name: 'jcr:title', value: query, operator: 'CONTAINS', caseSensitive: false }],
+                },
+                {
+                    fields: [{ name: 'title', value: query, operator: 'CONTAINS', caseSensitive: false }],
+                },
+            ];
+        } else if (query) {
+            // 1–2 char query: keep today's behavior (fullText only) to avoid huge substring scans.
             filter.fullText = {
                 text: encodeURIComponent(query),
-                // For info about modes: https://adobe-sites.redoc.ly/tag/Search#operation/fragments/search!path=query/filter/fullText/queryMode&t=request
                 queryMode: 'EDGES',
             };
         }
@@ -135,15 +165,31 @@ class AEM {
         }
 
         let cursor;
+        let firstFetch = true;
         while (true) {
             if (cursor) {
                 params.cursor = cursor;
             }
             const searchParams = new URLSearchParams(params).toString();
-            const response = await fetch(`${this.cfSearchUrl}?${searchParams}`, {
+            let response = await fetch(`${this.cfSearchUrl}?${searchParams}`, {
                 headers: this.headers,
                 signal: abortController?.signal,
             });
+
+            // Graceful degradation: the OR/property filter schema is only verifiable at runtime.
+            // If AEM rejects the mixed `any` body on the first request, drop to a fullText-only
+            // search and retry once, so search keeps working (client-side #skipQuery in
+            // mas-repository.js still provides partial title matching) instead of erroring out.
+            if (firstFetch && filter.any && (response.status === 400 || response.status === 422)) {
+                delete filter.any;
+                filter.fullText = { text: encodeURIComponent(query), queryMode: 'EDGES' };
+                params.query = JSON.stringify(searchQuery);
+                response = await fetch(`${this.cfSearchUrl}?${new URLSearchParams(params).toString()}`, {
+                    headers: this.headers,
+                    signal: abortController?.signal,
+                });
+            }
+            firstFetch = false;
 
             if (!response.ok) {
                 throw new Error(`Search failed: ${response.status} ${response.statusText}`);

--- a/studio/test/aem/aem.test.js
+++ b/studio/test/aem/aem.test.js
@@ -34,6 +34,22 @@ describe('aem.js', () => {
     });
 
     describe('method: searchFragment', () => {
+        // These assert request serialization only — the OR/property filter schema is unverifiable
+        // from docs, so true server behavior is proven by a live probe and the Nala E2E spec.
+        const parseFilter = (url) => {
+            const params = new URL(url, 'http://test').searchParams;
+            return JSON.parse(params.get('query')).filter;
+        };
+
+        const stubSinglePage = (items = []) => {
+            const calls = [];
+            window.fetch = async (url) => {
+                calls.push(url);
+                return { ok: true, json: async () => ({ items }) };
+            };
+            return calls;
+        };
+
         it('should fetch content fragments with multiple calls', async () => {
             window.fetch = async (url) => {
                 if (url.includes('cursor1')) {
@@ -76,6 +92,97 @@ describe('aem.js', () => {
                 { id: 1, fields: [{ name: 'variant', value: 'v1' }] },
                 { id: 2, fields: [{ name: 'variant', value: 'v2' }] },
             ]);
+        });
+
+        it('ORs fullText, jcr:title, and the title content field for a normal query', async () => {
+            const calls = stubSinglePage([]);
+            for await (const _ of aem.searchFragment({ path: '/x', query: 'photo' })) {
+                // drain
+            }
+            expect(calls).to.have.lengthOf(1);
+            const filter = parseFilter(calls[0]);
+            expect(filter.path).to.equal('/x');
+            expect(filter.any).to.be.an('array').with.lengthOf(3);
+
+            const fullTextBranch = filter.any.find((b) => b.fullText);
+            expect(fullTextBranch.fullText.text).to.equal(encodeURIComponent('photo'));
+            expect(fullTextBranch.fullText.queryMode).to.equal('EDGES');
+
+            const propBranch = filter.any.find((b) => b.properties);
+            expect(propBranch.properties).to.deep.equal([
+                { name: 'jcr:title', value: 'photo', operator: 'CONTAINS', caseSensitive: false },
+            ]);
+
+            const fieldBranch = filter.any.find((b) => b.fields);
+            expect(fieldBranch.fields).to.deep.equal([
+                { name: 'title', value: 'photo', operator: 'CONTAINS', caseSensitive: false },
+            ]);
+        });
+
+        it('omits all text conditions when the query is empty', async () => {
+            const calls = stubSinglePage([]);
+            for await (const _ of aem.searchFragment({ path: '/x' })) {
+                // drain
+            }
+            const filter = parseFilter(calls[0]);
+            expect(filter.any).to.equal(undefined);
+            expect(filter.fullText).to.equal(undefined);
+            expect(filter.path).to.equal('/x');
+        });
+
+        it('falls back to fullText-only for a 1–2 char query', async () => {
+            const calls = stubSinglePage([]);
+            for await (const _ of aem.searchFragment({ path: '/x', query: 'ph' })) {
+                // drain
+            }
+            const filter = parseFilter(calls[0]);
+            expect(filter.any).to.equal(undefined);
+            expect(filter.fullText.text).to.equal(encodeURIComponent('ph'));
+            expect(filter.fullText.queryMode).to.equal('EDGES');
+        });
+
+        it('preserves tag, model, status, and createdBy filters alongside the text OR branch', async () => {
+            const calls = stubSinglePage([]);
+            for await (const _ of aem.searchFragment({
+                path: '/x',
+                query: 'photo',
+                tags: ['mas:status/draft'],
+                modelIds: ['m1'],
+                status: 'PUBLISHED',
+                createdBy: ['user@adobe.com'],
+            })) {
+                // drain
+            }
+            const filter = parseFilter(calls[0]);
+            expect(filter.any).to.be.an('array').with.lengthOf(3);
+            expect(filter.tags).to.deep.equal(['mas:status/draft']);
+            expect(filter.modelIds).to.deep.equal(['m1']);
+            expect(filter.status).to.deep.equal(['PUBLISHED']);
+            expect(filter.created.by).to.deep.equal(['user@adobe.com', 'USER@ADOBE.COM']);
+        });
+
+        it('degrades to fullText-only and retries once when AEM rejects the OR filter', async () => {
+            const calls = [];
+            window.fetch = async (url) => {
+                calls.push(url);
+                if (parseFilter(url).any) {
+                    return { ok: false, status: 400, statusText: 'Bad Request', json: async () => ({}) };
+                }
+                return { ok: true, json: async () => ({ items: [] }) };
+            };
+
+            const pages = [];
+            for await (const items of aem.searchFragment({ path: '/x', query: 'photo' })) {
+                pages.push(items);
+            }
+
+            expect(calls).to.have.lengthOf(2);
+            expect(parseFilter(calls[0]).any).to.be.an('array').with.lengthOf(3);
+            const retryFilter = parseFilter(calls[1]);
+            expect(retryFilter.any).to.equal(undefined);
+            expect(retryFilter.fullText.text).to.equal(encodeURIComponent('photo'));
+            expect(retryFilter.fullText.queryMode).to.equal('EDGES');
+            expect(pages).to.deep.equal([[]]);
         });
     });
 


### PR DESCRIPTION
## Summary
- Extends `searchFragment()` in `studio/src/aem/aem.js` to OR-combine `fullText`, `jcr:title`, and `title` content field conditions in a single AEM CF search request
- Adds a `MIN_TITLE_QUERY_LENGTH = 3` guard so 1–2 char queries fall back to `fullText`-only behavior
- Includes a graceful-degradation safeguard that retries with `fullText`-only if AEM rejects the mixed filter body (400/422)
- Adds unit tests asserting the request filter shape and Nala E2E tests for the user-facing acceptance criterion

## Issue
Closes #365

## Test plan
- [ ] `just health` passes for all services
- [ ] `just test` passes
- [ ] Manual smoke test of changed functionality

## Test URLs

- Before: https://main--mas-pinata--adobecom.aem.live/
- After: https://mwpw-190535--mas-pinata--adobecom.aem.live/