### PR TITLE
Add the fiesta tenant contract

### DIFF
--- a/.pinata/README.md
+++ b/.pinata/README.md
@@ -1,0 +1,48 @@
+# `.pinata/` — M@S's harness contract
+
+How M@S drives the fiesta automation harness as a tenant. The harness holds no
+M@S-specific knowledge; everything M@S-specific lives here.
+
+| File               | What it declares                                                       |
+| ------------------ | ---------------------------------------------------------------------- |
+| `manifest.yaml`    | Identity (`org`/`product`/`repo`) and the shared mental models to use. |
+| `gates.yaml`       | Verification gates — replaces the harness's built-in set when present. |
+| `floor/gates.yaml` | Vendored acom org-floor snapshot, linted against in CI (INV-3).        |
+| `preview.yaml`     | Branch preview URLs and the visual gate's surface catalog.             |
+| `pr.yaml`          | Branch naming (Jira-key-first) and the PR body template.               |
+| `scripts/`         | Gate and CI helpers.                                                   |
+| `workflows/*.yaml` | M@S workflows composed from harness capability handlers.               |
+
+## Gates
+
+Six gates after a one-time `npm ci` provision:
+
+- **lint** — eslint over the diff's JS files (CI doesn't lint; the tree has old debt).
+- **format** — `npx prettier --check .`, same as CI.
+- **unit-tests** — `npm test` across all workspaces, incl. coverage thresholds.
+- **dist-sync** — rebuild bundle + docs, fail on drift (demo pages load the
+  checked-in `dist/mas.js`).
+- **adversary** — independent-model diff review, required by the acom floor.
+- **visual** — screenshots the surfaces the catalog routes the change to; a
+  change nothing can render escalates to a human.
+
+No structure gate: test co-location is already enforced by the runner globbing
+plus coverage thresholds.
+
+## Preview
+
+Branches serve at `<branch>--mas-pinata--adobecom.aem.page`. Feature branches must be
+named `MWPW-XXXXXX` (IMS regex), which is why `pr.yaml` puts the Jira key first.
+Authenticated surfaces like `/studio.html` need IMS credentials; the docs
+galleries render without auth. Studio has no surface yet — adding one takes an
+`auth_profiles` entry plus a `capture_hosts` binding.
+
+## Mental models
+
+`manifest.yaml` selects shared models by id; content resolves from the registry
+at run time rather than being copied into each repo.
+
+## Workflows
+
+`workflows/restyle-component.yaml` composes `codegen.generate` →
+`approval.request`; the harness namespaces it to `mas.restyle-component`.

--- a/.pinata/floor/gates.yaml
+++ b/.pinata/floor/gates.yaml
@@ -1,0 +1,32 @@
+# acom org floor (INV-3, R-8) — the verification minimum every acom product
+# must meet. A tenant's .pinata/gates.yaml may add gates or tighten these,
+# never weaken them: run_gates and the gate.run handler enforce this at run
+# time (packages/verification/gate_strictness.py), and each tenant repo lints
+# its contract against its vendored floor snapshot (.pinata/floor/gates.yaml)
+# in CI.
+#
+# This file is org POLICY and part of the TCB (see .pinata/gates.yaml
+# tcb-guard): the platform team changes it; the self-improvement loop may not.
+regeneration:
+    # Maximum total producer candidates; tenants inherit or tighten downward.
+    max_candidates: 5
+
+gates:
+    adversary:
+        template: adversary
+        name: Adversarial review — independent merge gate (INV-4)
+        description: >-
+            A change merges on an independent adversary's verdict (different model
+            class, no producer context), never the producer's self-assessment.
+            Binds every acom product; tenants may tighten but not drop it. Skips
+            honestly when no adversary model is reachable in dev.
+        blocking: true
+        # TODO(operator, temporary — 2026-07-06): loosened from `escalate_to_human`
+        # to `regenerate` so an adversary failure re-enters codegen for a bounded
+        # producer rebuild (regeneration.max_candidates) with the concerns as feedback,
+        # escalating to a human only at round exhaustion — instead of stopping on the
+        # first failure. This is an INV-6 TCB change made under explicit operator
+        # authority (the loop itself may not make it). It only RELAXES the floor
+        # (tenants may still tighten to escalate_to_human); revisit the round budget
+        # and re-tighten as the loop earns trust.
+        failure_route: regenerate

--- a/.pinata/gates.yaml
+++ b/.pinata/gates.yaml
@@ -1,0 +1,92 @@
+# M@S verification gates. When this file is present the harness runs these
+# in place of its built-in set; commands run in the worktree.
+
+# Producer rebuild budget for gates that route to regenerate; the acom floor
+# caps it at 5 and tenants may only tighten it.
+regeneration:
+    max_candidates: 5
+
+# Checked-in build outputs that ship with any src change. dist-sync requires
+# them, so the candidate scope check must not reject them as unplanned.
+generated:
+    - 'web-components/dist/**'
+    - 'web-components/docs/**'
+
+# Command gates need the pinned devDeps. CI's extra milo#stage install is
+# vestigial — nothing here imports milo.
+provision: npm ci
+
+gates:
+    lint:
+        template: command
+        name: ESLint (changed files)
+        # Diff-scoped: upstream CI doesn't lint and the tree carries old violations.
+        cmd: npx eslint {js_files}
+        blocking: true
+        failure_route: repair_loop
+        repair:
+            cmd: npx eslint {js_files} --fix
+
+    format:
+        template: command
+        name: Prettier formatting check
+        # Same repo-wide check as CI's check-formatting workflow.
+        cmd: npx prettier --check .
+        blocking: true
+        failure_route: repair_loop
+        # The tree is prettier-clean at base, so failures are always in the
+        # changed files; writing only those keeps the repair inside its boundary.
+        repair:
+            cmd: npx prettier --write {changed_files} --ignore-unknown
+
+    unit-tests:
+        template: command
+        name: Unit suites, all workspaces
+        cmd: npm test
+        timeout_s: 600
+        blocking: true
+        # Test failures usually need files outside the one-file repair boundary
+        # (e.g. a store signal the tests expect), so send them back to the producer.
+        failure_route: regenerate
+
+    dist-sync:
+        template: command
+        name: Built artifacts in sync (web-components)
+        # Demo pages load the checked-in dist/mas.js, so a stale bundle hides
+        # src changes from the visual gate. Mirrors CI's web-components-pr check.
+        cmd: bash .pinata/scripts/check-dist-sync.sh
+        timeout_s: 300
+        blocking: true
+        # A repair step can't rebuild the bundle (the missing dist files sit
+        # outside its mutation boundary), so the producer redoes the candidate.
+        failure_route: regenerate
+
+    visual:
+        template: visual
+        name: Visual evidence (component demo surfaces)
+        # No default page: the surface catalog in preview.yaml routes targets,
+        # and a change no surface can show escalates instead of guessing.
+        breakpoints: [1200]
+        # Short clip per target for the human reviewer; the judge stays on stills.
+        video: true
+        on_missing_target: escalate
+        criteria: >-
+            The changed component renders on its demo gallery without layout
+            breakage or overlap at each breakpoint; spacing, alignment and
+            typography hold, prices resolve to real currency values, and
+            neighboring cards are not regressed.
+        require_human: true
+        blocking: true
+
+    # Last on purpose: the adversary reviews the code together with every
+    # deterministic and visual gate result, not blind of them.
+    adversary:
+        template: adversary
+        name: Adversarial review — independent merge gate (INV-4)
+        description: >-
+            Independent-model review of the diff before merge, required by the
+            acom org floor. Skips honestly when no adversary model is reachable.
+        blocking: true
+        # Follow the floor's 2026-07-06 posture: bounded producer rebuild with the
+        # concerns as feedback, human review only at round exhaustion.
+        failure_route: regenerate

--- a/.pinata/manifest.yaml
+++ b/.pinata/manifest.yaml
@@ -1,0 +1,17 @@
+# Fiesta tenant contract — M@S (Merch at Scale) identity and references.
+#
+# The harness reads this at the pinned commit and holds no M@S-specific
+# knowledge of its own. Identity ladder: adobe (company) > acom (org) >
+# mas (product) > … . Unknown keys are rejected, so a typo fails loudly.
+org: acom
+product: mas
+repo: adobecom/mas-pinata
+owners_from: CODEOWNERS
+
+# Which shared mental models the planner should consult for M@S work.
+# Selection is tenant-owned; the model content is resolved from the shared
+# registry at run time (see .pinata/README.md).
+mental_models:
+    use:
+        - mas-web-components
+        - mas-studio

--- a/.pinata/pr.yaml
+++ b/.pinata/pr.yaml
@@ -1,0 +1,19 @@
+# PR body and branch naming for harness-authored changes. Unresolvable
+# placeholders fall back as declared below.
+issue_key_pattern: 'MWPW-\d{6}'
+# Jira key first: the IMS regex only accepts MWPW-XXXXXX branch previews.
+branch_pattern: ['{issue_key}', '{title_slug}']
+page: /web-components/docs/merch-card.html
+fallbacks:
+    issue_key: 'Resolves: <!-- link the MWPW Jira ticket, e.g. [MWPW-0000](…) -->'
+    # Keep the Before/After shape honest when a run has no visual evidence.
+    test_urls: |-
+        - Before: https://main--mas-pinata--adobecom.aem.page/web-components/docs/merch-card.html?martech=off
+        - After: <!-- no verified visual evidence this run — see the run dashboard -->
+template: |
+    {summary_bullets}
+
+    Resolves: [{issue_key}](https://jira.corp.adobe.com/browse/{issue_key})
+
+    **Test URLs** (the before/after pair the harness visually verified):
+    {test_urls}

--- a/.pinata/preview.yaml
+++ b/.pinata/preview.yaml
@@ -1,0 +1,253 @@
+# EDS branch previews: {branch}--mas-pinata--adobecom.aem.page. Branches must be
+# named MWPW-XXXXXX: IMS only accepts that shape as a Studio redirect target,
+# and an unregistered origin sends the login to www.adobe.com instead.
+mechanism: aem-branch-preview
+pin_pattern: 'https://{branch}--mas-pinata--adobecom.aem.page{page}?martech=off'
+# Consumer pages load branch web components via ?maslibs= (a value containing
+# '--' is a full host label, so the fork resolves). Docs pages ignore maslibs.
+# The host here must be a mas-owned one: a consumer host in this pattern
+# shadows pasted consumer URLs and strips them to bare paths.
+overlay_pattern: 'https://main--mas--adobecom.aem.page{page}?maslibs={branch}--mas-pinata--adobecom&martech=off'
+
+# Local serve (preferred): the repo's own dev server on the diff-applied
+# worktree. Port 3000 is what maslibs=local resolves to in consumer bootstraps.
+# Galleries hydrate from prod services (mas/io, WCS) so they render fully here.
+local:
+    # Studio's author proxy runs alongside aem up. proxy:stage points it at the
+    # stage author, so automated captures never read or write production content,
+    # and PROXY_PORT moves it off 8080 where the harness gateway already listens.
+    # The until-loop serializes readiness: the harness only polls port 3000, so a
+    # proxy that never binds would otherwise leave aem up healthy and the promotions
+    # view rendering an empty list, which photographs as real evidence.
+    cmd: 'PROXY_PORT=8091 npm --prefix studio run proxy:stage & until curl -s -o /dev/null -X OPTIONS http://127.0.0.1:8091/; do sleep 0.5; done; aem up --port=3000 --no-open --stop-other --url https://main--mas--adobecom.aem.page'
+    # proxy.port tells studio.html which author proxy to call; galleries ignore it.
+    url: 'http://localhost:3000{page}?proxy.port=8091'
+    # Foreign consumer pages stay remote on the public content host and pull
+    # web components from this server via maslibs=local. studio.html is listed as
+    # an own host instead: it loads its code by relative path, so only serving it
+    # from here shows the candidate build. maslibs would be a no-op for it.
+    consumer_overlay:
+        own_hosts: ['--mas--', '--mas-pinata--', 'mas.adobe.com']
+        params: 'maslibs=local&martech=off'
+
+# Hosts that carry mas pages when a requester pastes a URL: studio deep links
+# and da-cc consumer pages in practice. Live URLs capture on the .page host.
+capture_hosts:
+    - '--mas--adobecom.aem.page'
+    # Our own branch previews: an IMS-registered origin, so Studio can log in here.
+    - '--mas-pinata--adobecom.aem.page'
+    # Studio deep links are pasted on the production domain. Without this entry
+    # the URL is dropped and the gate has nothing to capture. The page is served
+    # from the local worktree (own_hosts above), so production is never shot.
+    - host: 'mas.adobe.com'
+      auth: ims
+    - host: '--da-cc--adobecom.aem.page'
+      auth: da-cc-token
+    - host: '--mas--adobecom.aem.live'
+      capture_on: '--mas--adobecom.aem.page'
+    - host: '--mas-pinata--adobecom.aem.live'
+      capture_on: '--mas-pinata--adobecom.aem.page'
+    - host: '--da-cc--adobecom.aem.live'
+      capture_on: '--da-cc--adobecom.aem.page'
+
+# IMS login for Studio surfaces, same account and flow already verified on the
+# milo tenant. Dormant until a capture_hosts entry attaches it via auth: ims.
+auth_profiles:
+    da-cc-token:
+        token_env: AEM_SITE_TOKEN_DA_CC
+        header: 'authorization: token {token}'
+    ims:
+        account:
+            username: cod23684+masautomation@adobetest.com
+            password_env: IMS_PASS
+        idp_hosts: [auth.services.adobe.com, ims-na1.adobelogin.com]
+        steps:
+            - fill: '#EmailPage-EmailField'
+              value_from: username
+              timeout_ms: 45000
+            - click: '[data-id=EmailPage-ContinueButton]'
+            # IMS sometimes ignores Continue: redo email+Continue until the password page shows; toaster = account rejected.
+            - fill: '#PasswordPage-PasswordField'
+              value_from: password
+              timeout_ms: 60000
+              retry_previous: 2
+              retry_interval_ms: 1000
+              retry_max_replays: 4
+              abort_on: ['[data-id=EmailPage-Toaster]']
+            - click: '[data-id=PasswordPage-ContinueButton]'
+            # Profile chooser and passkey nudge are interstitials; skip if absent.
+            - click: '[data-id="PP-ProfileChooser-AuthAccount"]'
+              optional: true
+              timeout_ms: 8000
+            - click: 'button:has-text("Skip"), [data-id="PasskeyNudgePage-SkipButton"]'
+              optional: true
+              timeout_ms: 8000
+        settle_ms: 5000
+
+# Demo galleries under web-components/docs/ (code-bus pages, real fragments).
+# Every surface declares a match glob; a change no glob covers escalates.
+surfaces:
+    - id: merch-card
+      page: /web-components/docs/merch-card.html
+      description: >-
+          Generic merch-card gallery with many variants side by side — fallback
+          for cross-cutting web-components changes. Prefer a dedicated gallery
+          when one matches; pick nothing for changes cards can't render.
+      match: 'web-components/src/*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: ccd
+      page: /web-components/docs/ccd.html
+      description: CCD slice and suggested cards in a dense grid.
+      match: 'web-components/src/variants/ccd-*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: fries
+      page: /web-components/docs/fries.html
+      description: Fries cards, incl. border/gradient treatments and sizes.
+      match: 'web-components/src/variants/fries*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: catalog
+      page: /web-components/docs/catalog.html
+      description: Catalog variant cards.
+      match: 'web-components/src/variants/catalog*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: plans
+      page: /web-components/docs/plans.html
+      description: Plans and plans-v2 pricing cards with badges and quantity selectors.
+      match: 'web-components/src/variants/plans*'
+      requires:
+          - /web-components/docs/styles.css
+
+    - id: inline-price
+      page: /web-components/docs/inline-price.html
+      description: >-
+          Inline price spans in every configuration: promo, strikethrough, tax
+          and per-unit labels, locale price literals.
+      match: 'web-components/*price*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: checkout
+      page: /web-components/docs/checkout-link.html
+      description: Checkout links and buttons with workflow-step, quantity and promo params.
+      match: 'web-components/src/checkout-*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: feature-flags
+      page: /web-components/docs/feature-flags.html
+      description: mas-ff-* flag docs with flag-sensitive price examples.
+      match: 'web-components/src/mas-commerce-service*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: aem-fragment
+      page: /web-components/docs/aem-fragment.html
+      description: Cards hydrated from real fragment UUIDs via the DA mount.
+      match: 'web-components/src/aem-fragment*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    - id: plans-collection
+      page: /web-components/docs/plans-collection.html
+      description: >-
+          Plans collection gallery, grouped plans cards driven by the
+          merch-card-collection element.
+      match: 'web-components/src/merch-card-collection*'
+      requires:
+          - /web-components/docs/spectrum.css
+          - /web-components/docs/styles.css
+
+    # Mined from adobecom/mas merged PR test urls (full history, 745 PRs
+    # 2024-06 to 2026-07; each probed HTTP 200, public, never a /drafts/ page).
+    # Consumer pages stay on .aem.live, their .aem.page previews are ims gated.
+    # The pre-2025-10 window adds no pages: its unique urls are all dead or
+    # ims gated (old ccd galleries 404, studio deeplinks gated).
+    - id: cc-plans
+      url: https://main--cc--adobecom.aem.live/creativecloud/plans?martech=off
+      description: >-
+          Production Creative Cloud plans page (en-US baseline), plans cards
+          with badges, quantity select and legal labels, hydrated through the
+          mas.adobe.com fragment delivery pipeline. Pick for io/www transformer
+          changes or plans work that needs real production context; the
+          localized siblings below cover locale-specific rendering.
+      match: 'io/www/src/*'
+
+    - id: cc-plans-fr
+      url: https://main--cc--adobecom.aem.live/fr/creativecloud/plans?martech=off
+      description: >-
+          French Creative Cloud plans page, localized price literals: TTC
+          suffix, comma decimals, euro placement. Pick for price-literals or
+          locale string changes where the exact French strings must render;
+          for tax-label markup itself prefer cc-plans-kr.
+      match: 'web-components/price-literals.json'
+
+    - id: cc-plans-kr
+      url: https://main--cc--adobecom.aem.live/kr/creativecloud/plans?martech=off
+      description: >-
+          Korean Creative Cloud plans page, tax-inclusive label strings and
+          full-width punctuation across every plans card. Pick for price
+          template or tax-label rendering changes that need a whole page of
+          localized cards, not one isolated card.
+      match: 'web-components/src/price/template.js'
+
+    - id: cc-plans-ar
+      url: https://main--cc--adobecom.aem.live/ar/creativecloud/plans?martech=off
+      description: >-
+          Arabic Creative Cloud plans page, right to left layout across plans
+          cards. Pick for direction sensitive layout changes.
+      match: 'web-components/src/global.css.js'
+
+    - id: cc-products-catalog
+      url: https://main--cc--adobecom.aem.live/products/catalog?martech=off
+      description: >-
+          Production products catalog, catalog cards inside a collection with
+          search, sidenav filters and load more.
+      match: 'web-components/src/sidenav/*'
+
+    - id: cc-segment-blade
+      url: https://main--cc--adobecom.aem.live/au/cc-shared/fragments/merch/creativecloud/illustration/merch-card/segment-blade?martech=off
+      description: >-
+          Single segment card fragment page with a real AU offer, exercises
+          price templates, per unit and tax labels on one isolated card.
+      match: 'web-components/src/price/*'
+
+    - id: dc-bizpro-plans
+      url: https://main--da-dc--adobecom.aem.live/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?martech=off
+      description: >-
+          BizPro plan cards with VAT legal pricing on the DC ace1205 campaign
+          fragment page. Pick for bizpro variant or business-pricing legal
+          label changes.
+      match: 'web-components/src/variants/bizpro*'
+
+    - id: express-pricing
+      url: https://main--da-express-milo--adobecom.aem.live/jp/express/pricing?martech=off
+      description: >-
+          Japanese Adobe Express pricing page with the full and simplified
+          pricing express cards; JP titles double as a long-title wrapping
+          check. Pick for the express card variants.
+      match: 'web-components/src/variants/*pricing-express*'
+
+    - id: milo-merch-kitchen-sink
+      url: https://main--milo--adobecom.aem.page/merch/kitchen-sink?martech=off
+      description: >-
+          Merch kitchen sink on the milo host, every card variant on one page
+          with real fragments. Production-content sibling of the local
+          merch-card gallery, pick for merch-card chrome changes (badges,
+          strokes, hydration) that need real content-bus context.
+      match: 'web-components/src/merch-card.js'

--- a/.pinata/scripts/check-contract.py
+++ b/.pinata/scripts/check-contract.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Reference-integrity check for the .pinata/ tenant contract (R-14).
+
+Validates that the contract files parse with their required shapes, and that
+every mental-model id declared in manifest.yaml resolves to a directory in the
+shared registry (Adobe-acom/pinata-tool-shelf). Contract-shape problems always
+fail; the registry check degrades to a warning when the registry cannot be
+cloned (e.g. no token in a fork's CI).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+FIESTA = Path(__file__).resolve().parents[1]
+REGISTRY_URL = "https://github.com/Adobe-acom/pinata-tool-shelf.git"
+errors: list[str] = []
+
+
+def _load(name: str, required: bool = False) -> dict | None:
+    path = FIESTA / name
+    if not path.exists():
+        if required:
+            errors.append(f"{name}: missing (required)")
+        return None
+    try:
+        data = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        errors.append(f"{name}: malformed YAML: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{name}: must be a mapping")
+        return None
+    return data
+
+
+manifest = _load("manifest.yaml", required=True) or {}
+for field in ("org", "product", "repo"):
+    if not manifest.get(field):
+        errors.append(f"manifest.yaml: missing required field '{field}'")
+
+gates = _load("gates.yaml")
+if gates is not None:
+    for gate_id, defn in (gates.get("gates") or {}).items():
+        if not isinstance(defn, dict) or not defn.get("template"):
+            errors.append(f"gates.yaml: gate '{gate_id}' needs a template")
+
+
+def _regeneration_max(document: dict | None, label: str) -> int | None:
+    if document is None or "regeneration" not in document:
+        return None
+    policy = document["regeneration"]
+    if not isinstance(policy, dict):
+        errors.append(f"{label}: regeneration must be a mapping")
+        return None
+    unknown = sorted(set(policy) - {"max_candidates"})
+    if unknown:
+        errors.append(f"{label}: regeneration has unknown fields {unknown}")
+    value = policy.get("max_candidates")
+    if type(value) is not int or value < 1:
+        errors.append(f"{label}: regeneration.max_candidates must be a positive integer")
+        return None
+    return value
+
+
+def _route(defn: dict) -> str:
+    # Mirrors the harness default: an unset failure_route is the strictest.
+    return defn.get("failure_route") or "escalate_to_human"
+
+
+def _autonomous_route(defn: dict) -> bool:
+    return _route(defn) in {"repair_loop", "regenerate"}
+
+
+# INV-3 monotonic strictness (R-8): tenant gates may only tighten the org
+# floor, never weaken it. The floor snapshot is vendored at
+# .pinata/floor/gates.yaml (source of truth: fiesta config/floors/<org>/ —
+# the harness enforces THAT one at run time; this lint catches a weakening
+# PR in CI before it ever reaches a run).
+floor = _load("floor/gates.yaml")
+tenant_regeneration_max = _regeneration_max(gates, "gates.yaml")
+floor_regeneration_max = _regeneration_max(floor, "floor/gates.yaml")
+if floor is None:
+    print("WARN: no .pinata/floor/gates.yaml snapshot — INV-3 strictness lint skipped")
+elif gates is not None:
+    if (
+        floor_regeneration_max is not None
+        and tenant_regeneration_max is not None
+        and tenant_regeneration_max > floor_regeneration_max
+    ):
+        errors.append(
+            "gates.yaml: regeneration.max_candidates "
+            f"{tenant_regeneration_max} exceeds the org floor ceiling "
+            f"{floor_regeneration_max} (INV-3)"
+        )
+    tenant_gates = gates.get("gates") or {}
+    for name, fdef in (floor.get("gates") or {}).items():
+        tdef = tenant_gates.get(name)
+        if not isinstance(tdef, dict):
+            errors.append(f"gates.yaml: gate '{name}' is required by the org floor but missing (INV-3)")
+            continue
+        if tdef.get("template") != fdef.get("template"):
+            errors.append(
+                f"gates.yaml: gate '{name}' changes the org floor template "
+                f"'{fdef.get('template')}' to '{tdef.get('template')}' (INV-3)"
+            )
+        if fdef.get("blocking", True) and not tdef.get("blocking", True):
+            errors.append(f"gates.yaml: gate '{name}' is blocking in the org floor but advisory here (INV-3)")
+        if fdef.get("threshold") is not None and (
+            tdef.get("threshold") is None or tdef["threshold"] < fdef["threshold"]
+        ):
+            errors.append(
+                f"gates.yaml: gate '{name}' drops or lowers the org floor threshold {fdef['threshold']} (INV-3)"
+            )
+        if not _autonomous_route(fdef) and _autonomous_route(tdef):
+            errors.append(
+                f"gates.yaml: gate '{name}' downgrades the org floor failure_route "
+                f"to autonomous {_route(tdef)} (INV-3)"
+            )
+        if fdef.get("require_human", True) and not tdef.get("require_human", True):
+            errors.append(f"gates.yaml: gate '{name}' drops require_human, which the org floor mandates (INV-3)")
+
+preview = _load("preview.yaml")
+if preview is not None:
+    if not preview.get("pin_pattern"):
+        errors.append("preview.yaml: missing pin_pattern")
+    for i, surface in enumerate(preview.get("surfaces") or []):
+        label = f"preview.yaml: surfaces[{i}]"
+        if not isinstance(surface, dict) or not surface.get("id"):
+            errors.append(f"{label}: needs an id")
+            continue
+        if bool(surface.get("page")) == bool(surface.get("url")):
+            errors.append(f"preview.yaml: surface '{surface['id']}' needs exactly one of page/url")
+        if not surface.get("description"):
+            errors.append(
+                f"preview.yaml: surface '{surface['id']}' needs a description "
+                "(the selector's only page signal)"
+            )
+
+pr = _load("pr.yaml")
+if pr is not None and not pr.get("template"):
+    errors.append("pr.yaml: missing template")
+
+for wf in sorted((FIESTA / "workflows").glob("*.yaml")) if (FIESTA / "workflows").is_dir() else []:
+    try:
+        data = yaml.safe_load(wf.read_text()) or {}
+        if not data.get("workflow_id"):
+            errors.append(f"workflows/{wf.name}: missing workflow_id")
+    except yaml.YAMLError as exc:
+        errors.append(f"workflows/{wf.name}: malformed YAML: {exc}")
+
+ids = [str(i) for i in ((manifest.get("mental_models") or {}).get("use") or [])]
+if ids:
+    with tempfile.TemporaryDirectory() as tmp:
+        clone = subprocess.run(
+            ["git", "clone", "--depth", "1", REGISTRY_URL, tmp],
+            capture_output=True, text=True, timeout=120,
+        )
+        if clone.returncode != 0:
+            print(f"WARN: could not clone the mental-model registry — id check skipped:\n{clone.stderr[-300:]}")
+        else:
+            available = {p.name for p in (Path(tmp) / "mental-models").iterdir() if p.is_dir()}
+            dangling = [i for i in ids if i not in available]
+            if dangling:
+                errors.append(
+                    f"manifest.yaml: mental_models.use ids not in the registry: {dangling} "
+                    f"(available: {sorted(available)})"
+                )
+
+if errors:
+    print("fiesta contract check FAILED:")
+    for e in errors:
+        print(f"  - {e}")
+    sys.exit(1)
+print("fiesta contract check passed")

--- a/.pinata/scripts/check-dist-sync.sh
+++ b/.pinata/scripts/check-dist-sync.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Rebuild the web-components bundle + docs and fail on drift: the demo pages
+# load the checked-in dist/mas.js, and CI rejects out-of-sync build output.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+snapshot() {
+    find web-components/dist web-components/docs -type f -print0 |
+        sort -z | xargs -0 shasum -a 256 | shasum -a 256
+}
+
+before=$(snapshot)
+(cd web-components && npm run build:bundle && npm run build:docs)
+after=$(snapshot)
+
+if [ "$before" != "$after" ]; then
+    echo "FAIL: web-components dist/ or docs/ out of sync with src/." >&2
+    echo "Run 'cd web-components && npm run build:bundle && npm run build:docs' and commit." >&2
+    exit 1
+fi
+echo "OK: build artifacts in sync"

--- a/.pinata/workflows/restyle-component.yaml
+++ b/.pinata/workflows/restyle-component.yaml
@@ -1,0 +1,24 @@
+# A M@S workflow, composed from the harness capability library.
+#
+# workflow_id is namespaced to `mas.restyle-component` by the harness — do not
+# prefix it here. Each step names a registered handler; steps route by
+# on_success / on_failure to another step id or a terminal (`complete` / `__end__`).
+workflow_id: restyle-component
+name: Restyle a M@S web component
+description: >-
+    Generate a styling change to a web component (or one of its variants) from an
+    issue, then require human sign-off before it proceeds.
+start_step: generate
+steps:
+    - id: generate
+      handler: codegen.generate
+      # R-18: provider is explicit, never defaulted. contract_fixture is the
+      # inert demo output; switch to in_process_langgraph for real codegen.
+      inputs:
+          provider: contract_fixture
+      on_success: approve
+      on_failure: __end__
+    - id: approve
+      handler: approval.request
+      on_success: complete
+      on_failure: __end__


### PR DESCRIPTION
Ports the `.pinata/` contract from antonio-rmrz/mas and points its host references here.

- branch previews resolve to `{branch}--mas-pinata--adobecom.aem.page`, an origin IMS accepts as a Studio redirect target. The personal fork is unregistered, so its login lands on www.adobe.com and never returns
- `own_hosts` gains `--mas-pinata--`; it matches by substring, so `--mas--` does not cover this host
- `capture_hosts` covers our own `.page` previews and their `.live` siblings
- `issue_key_pattern` tightened to `MWPW-\d{6}`, the only branch shape IMS accepts
- `manifest.yaml` repo set to adobecom/mas-pinata

The existing `.pinata/.config.json` is untouched.
