### PR TITLE
Re-mint the da-cc site token in-run when expired

### DIFF
--- a/.pinata/preview.yaml
+++ b/.pinata/preview.yaml
@@ -56,6 +56,9 @@ auth_profiles:
     da-cc-token:
         token_env: AEM_SITE_TOKEN_DA_CC
         header: 'authorization: token {token}'
+        # expired token self-heals: the engine re-mints via the ims login in-run
+        mint:
+            login: ims
     ims:
         account:
             username: cod23684+masautomation@adobetest.com


### PR DESCRIPTION
- the da-cc-token profile now declares mint: {login: ims}
- on an expired AEM_SITE_TOKEN_DA_CC the engine signs the aem CLI in with the ims profile and swaps a fresh token in, instead of escalating
- engine side landed in fiesta fix/preview-infra-skip-integrity (0b1fb63); mint chain proven live against da-cc