### PR TITLE
Protect dependency lockfiles

### DIFF
--- a/.pinata/gates.yaml
+++ b/.pinata/gates.yaml
@@ -6,8 +6,8 @@
 regeneration:
     max_candidates: 5
 
-# Checked-in build outputs that ship with any src change. dist-sync requires
-# them, so the candidate scope check must not reject them as unplanned.
+# Checked-in build outputs that ship with any src change. dist-sync rebuilds
+# and compares them; the adversary skips them by default.
 generated:
     - 'web-components/dist/**'
     - 'web-components/docs/**'
@@ -17,6 +17,17 @@ generated:
 provision: npm ci
 
 gates:
+    lockfiles:
+        template: protected_paths
+        name: Dependency lockfiles
+        # An npm install during a code change rewrites these as a side effect.
+        # Dependency bumps are their own ticket.
+        paths:
+            - 'package-lock.json'
+            - '*/package-lock.json'
+        blocking: true
+        failure_route: escalate_to_human
+
     lint:
         template: command
         name: ESLint (changed files)


### PR DESCRIPTION
- Adds a `lockfiles` gate covering `package-lock.json` and any nested lockfile. It runs first and escalates to a human rather than shipping the change.
- An npm install during a code change rewrites these as a side effect. Recent runs carried that churn into the diff, and the engine check that used to strip it has been removed.
- Corrects the comment above `generated`, which still described that removed check.
