### PR TITLE
Skip flaky studio tests

### DIFF
--- a/studio/test/aem/aem-tag-picker-field.test.html
+++ b/studio/test/aem/aem-tag-picker-field.test.html
@@ -231,7 +231,7 @@
                         expect(spSearch).to.not.be.null;
                     });
 
-                    it('keeps selections made across different filters when applying', async function () {
+                    it.skip('keeps selections made across different filters when applying', async function () {
                         const aemTagPicker = initElementFromTemplate('tagPicker7', this.test.title);
                         await aemTagPicker.loadTags();
                         await aemTagPicker.updateComplete;

--- a/studio/test/aem/mas-filter-panel.test.html
+++ b/studio/test/aem/mas-filter-panel.test.html
@@ -95,7 +95,7 @@
                         expect(filterPanel.tagsByType.offer_type).to.have.lengthOf(1);
                     });
 
-                    it('Should update store when tags change', async function () {
+                    it.skip('Should update store when tags change', async function () {
                         const filterPanel = initElementFromTemplate('filterPanel1', this.test.title);
                         await filterPanel.updateComplete;
 

--- a/studio/test/editors/mas-compare-chart-editor.test.html
+++ b/studio/test/editors/mas-compare-chart-editor.test.html
@@ -230,7 +230,7 @@
                         Store.editor.referencedFragmentStoresHaveChanges.set(false);
                     });
 
-                    it('renders three cards, sections, features, and authored feature tooltips', async () => {
+                    it.skip('renders three cards, sections, features, and authored feature tooltips', async () => {
                         const fragmentStore = generateFragmentStore(structuredClone(compareChartSeed));
                         const el = await fixture(
                             html`<mas-compare-chart-editor .fragmentStore=${fragmentStore}></mas-compare-chart-editor>`,

--- a/studio/test/editors/merch-card-editor.test.html
+++ b/studio/test/editors/merch-card-editor.test.html
@@ -356,7 +356,7 @@
                         Store.editor.resetChanges();
                     });
 
-                    it('removes inherited mnemonic and restores it via override indicator', async () => {
+                    it.skip('removes inherited mnemonic and restores it via override indicator', async () => {
                         await setupTestEnvironment();
                         expect(editor.getFieldState('mnemonicIcon')).to.equal('inherited');
                         expect(editor.mnemonics).to.have.length(1);
@@ -383,7 +383,7 @@
                         expect(editor.mnemonics).to.have.length(1);
                     });
 
-                    it('removes inherited badge values and restores it via override indicator', async () => {
+                    it.skip('removes inherited badge values and restores it via override indicator', async () => {
                         await setupTestEnvironment();
                         expect(editor.getFieldState('badge')).to.equal('inherited');
                         expect(editor.getFieldState('badgeColor')).to.equal('inherited');
@@ -448,7 +448,7 @@
                         );
                     });
 
-                    it('maintains inherited state after add visual then cancel', async () => {
+                    it.skip('maintains inherited state after add visual then cancel', async () => {
                         // This test reproduces the bug where:
                         // 1. Click "Restore override" on Visuals (resets to inherit from parent)
                         // 2. Click "Add visual"
@@ -498,7 +498,7 @@
                     ];
 
                     restoreTests.forEach(({ name, field, selector, value }) => {
-                        it(`restoring ${name} activates save button`, async () => {
+                        it.skip(`restoring ${name} activates save button`, async () => {
                             await setupTestEnvironment({ [field]: value }, field);
                             expect(editor.getFieldState(field)).to.equal('overridden');
                             expect(saveNavItem.disabled).to.be.true;
@@ -529,7 +529,7 @@
                         expect(saveNavItem.disabled).to.be.false;
                     });
 
-                    it('renders grouped-variation-tags as readonly in non en_US locales', async () => {
+                    it.skip('renders grouped-variation-tags as readonly in non en_US locales', async () => {
                         await setupTestEnvironment(
                             { path: '/content/dam/mas/nala/en_AU/pzn/test-grouped-variation-readonly' },
                             'grouped-variation-readonly',
@@ -540,7 +540,7 @@
                         expect(groupedTagsPicker.readonly).to.be.true;
                     });
 
-                    it('renders grouped-variation-tags as editable in en_US locale', async () => {
+                    it.skip('renders grouped-variation-tags as editable in en_US locale', async () => {
                         await setupTestEnvironment(
                             { path: '/content/dam/mas/nala/en_US/pzn/test-grouped-variation-editable' },
                             'grouped-variation-editable',
@@ -1107,7 +1107,7 @@
                         });
                     });
 
-                    it('update quantity selection value and then rollback to the settings value', async () => {
+                    it.skip('update quantity selection value and then rollback to the settings value', async () => {
                         await setupTestEnvironment();
 
                         const field = editor.querySelector('#quantity-select-settings-field');

--- a/studio/test/promotions/mas-promotions-items-table.test.js
+++ b/studio/test/promotions/mas-promotions-items-table.test.js
@@ -1480,7 +1480,7 @@ describe('MasPromotionsItemsTable', () => {
             expect(toastStub.firstCall.args[0].content).to.include('Could not verify');
         });
 
-        it('populates existingPromoVariationsByPath when the repository resolves a promo variation', async () => {
+        it.skip('populates existingPromoVariationsByPath when the repository resolves a promo variation', async () => {
             setupPromotionInEdit();
             Store.promotions.selectedCards.set([defaultPath]);
 
@@ -1508,7 +1508,7 @@ describe('MasPromotionsItemsTable', () => {
             Store.promotions.selectedCards.set([]);
         });
 
-        it('keeps the previously known promo variation when a re-sync lookup fails transiently', async () => {
+        it.skip('keeps the previously known promo variation when a re-sync lookup fails transiently', async () => {
             setupPromotionInEdit();
             const otherPath = '/content/dam/mas/sandbox/en_US/other-card';
             const otherFragment = { ...cardFragment, path: otherPath, id: 'other-card-id' };


### PR DESCRIPTION
- Marks 12 `it()` declarations as `it.skip`, covering the 13 distinct failures seen on a clean checkout of main. One of them is generated by a `forEach` over 4 entries, so 15 cases are disabled in total.
- These fail intermittently with no code change. Two consecutive local runs on the same commit gave 6 failures, then 13. CI on main alternates green and red across commits that only touch YAML.
- Effect measured locally: 13 failures before, 1 after.
- Not fully deterministic yet. The run after these skips surfaced a new one, `tags field restore activates save`, in the same `merch-card-editor inheritance and overrides` block. That block holds 54 cases and looks like the shared cause rather than any individual test.
- The logs are full of `Failed to fetch` and 503s against `odinpreview.corp.adobe.com`. An unavailable dependency is the likely root; worth mocking before re-enabling.
