### PR TITLE
Skip flaky tags field restore test

### DIFF
--- a/studio/test/editors/merch-card-editor.test.html
+++ b/studio/test/editors/merch-card-editor.test.html
@@ -515,7 +515,7 @@
                         });
                     });
 
-                    it('tags field restore activates save', async () => {
+                    it.skip('tags field restore activates save', async () => {
                         await setupTestEnvironment({ tags: [{ id: 'mas:product/illustrator', title: 'Illustrator' }] }, 'tags');
                         editor.fragment.newTags = ['mas:product/illustrator'];
                         await editor.updateComplete;


### PR DESCRIPTION
Follow-up to #412.

#412 skipped seven flaky studio tests, including the parametrized `restoring ${name} activates save button` cases in `merch-card-editor.test.html`. The sibling test seventeen lines below it — `tags field restore activates save` — exercises the same tags-restore → save-button path and was left active.

It fails the same way: `editor.fragment` is undefined when the assertion runs, so the suite errors with `TypeError: Cannot set properties of undefined (setting 'newTags')`. It passes when run in isolation and fails intermittently under full-suite load — the same timing sensitivity that got the others skipped.

Observed on `main` at b2a3133 (3320 passing / 0 failing on one run, this test failing on the next with no code change between them).