### PR TITLE
[fiesta] MWPW-195301: Acrobat Lingo | aria-label text doesn't save in M@S cards

### DIFF
--- a/studio/src/rte/ost.js
+++ b/studio/src/rte/ost.js
@@ -75,7 +75,7 @@ function getObjectDifference(values, defaults) {
     return difference;
 }
 
-export const attributeFilter = (key) => /^(class|data-|is|href|title|target)/.test(key);
+export const attributeFilter = (key) => /^(class|data-|is|href|title|target|aria-)/.test(key);
 
 const OST_TYPE_MAPPING = {
     price: null,

--- a/studio/test/rte/ost.test.js
+++ b/studio/test/rte/ost.test.js
@@ -2,8 +2,31 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import '../../../web-components/dist/mas.js';
 
+import { attributeFilter } from '../../src/rte/ost.js';
 import { EVENT_OST_SELECT } from '../../src/constants.js';
 import Store from '../../src/store.js';
+
+describe('attributeFilter', () => {
+    it('passes class, data-*, is, href, title, target', () => {
+        expect(attributeFilter('class')).to.be.true;
+        expect(attributeFilter('data-wcs-osi')).to.be.true;
+        expect(attributeFilter('is')).to.be.true;
+        expect(attributeFilter('href')).to.be.true;
+        expect(attributeFilter('title')).to.be.true;
+        expect(attributeFilter('target')).to.be.true;
+    });
+
+    it('passes aria-label and other aria-* attributes', () => {
+        expect(attributeFilter('aria-label')).to.be.true;
+        expect(attributeFilter('aria-describedby')).to.be.true;
+    });
+
+    it('rejects unrelated attributes', () => {
+        expect(attributeFilter('id')).to.be.false;
+        expect(attributeFilter('style')).to.be.false;
+        expect(attributeFilter('tabindex')).to.be.false;
+    });
+});
 
 describe('onPlaceholderSelect', () => {
     let dispatchEventStub;
@@ -45,10 +68,8 @@ describe('onPlaceholderSelect', () => {
             });
         }
 
-        ostRoot = document.createElement('div');
-        ostRoot.id = 'ost';
-        document.body.appendChild(ostRoot);
         ({ onPlaceholderSelect } = await import('../../src/rte/ost.js'));
+        ostRoot = document.querySelector('[data-ost-root]');
         dispatchEventStub = sinon.stub(ostRoot, 'dispatchEvent');
     });
 
@@ -214,7 +235,7 @@ describe('onPlaceholderSelect with mas-ff-defaults on', () => {
         resolvePriceTaxFlagsStub = sinon.stub(masCommerceService, 'resolvePriceTaxFlags').resolves({});
 
         ({ onPlaceholderSelect } = await import('../../src/rte/ost.js'));
-        dispatchEventStub = document.getElementById('ost').dispatchEvent;
+        dispatchEventStub = document.querySelector('[data-ost-root]').dispatchEvent;
     });
 
     after(() => {

--- a/studio/test/rte/rte-link-editor.test.html
+++ b/studio/test/rte/rte-link-editor.test.html
@@ -94,6 +94,26 @@
                         });
                     });
 
+                    it('should include ariaLabel in save event when set', async function () {
+                        const linkEditor = await createFromTemplate('default', this.test.title);
+                        linkEditor.ariaLabel = 'Buy Adobe Acrobat';
+                        await linkEditor.updateComplete;
+
+                        const listener = oneEvent(linkEditor, 'save').then((e) => e.detail);
+                        linkEditor.shadowRoot.getElementById('saveButton').click();
+                        const detail = await listener;
+                        expect(detail.ariaLabel).to.equal('Buy Adobe Acrobat');
+                    });
+
+                    it('should omit ariaLabel from save event when empty', async function () {
+                        const linkEditor = await createFromTemplate('default', this.test.title);
+
+                        const listener = oneEvent(linkEditor, 'save').then((e) => e.detail);
+                        linkEditor.shadowRoot.getElementById('saveButton').click();
+                        const detail = await listener;
+                        expect(detail).to.not.have.property('ariaLabel');
+                    });
+
                     it('should emit close event', async function () {
                         const linkEditor = await createFromTemplate('default', this.test.title);
                         const listener = oneEvent(linkEditor, 'close');


### PR DESCRIPTION
* **`attributeFilter` in `ost.js` (line 78) only passes attributes matching `class`, `data-*`, `is`, `href`, `title`, or `target`. It excludes `aria-label`.**
* No errors. The warning is about the `.test.html` file not being in the ESLint config (expected — these are handled by the test runner separately).
* Now I understand the issue. The test file now has a top-level static import `import { attributeFilter } from '../../src/rte/ost.js'` added at line 5. This causes `ost.js` to be evaluated at module load time (before any `before` hooks run), which means `ost.js` creates its own `#ost` element. Then the `before` block creates a **second** `#ost` element and stubs its `dispatchEvent` — but `onPlaceholderSelect` dispatches on the original element that `ost.js` cached internally.
* All 22 tests pass. The fix: the new static `import { attributeFilter }` at the top of the test file caused `ost.js` to run its module-level code eagerly (creating a div with `data-ost-root` but no `id="ost"`). The `before` block was then creating a second orphan element and stubbing it — but `onPlaceholderSelect` dispatched on the original internal element. The fix replaces both `document.getElementById('ost')` lookups with `document.querySelector('[data-ost-root]')` to reference the element…

Resolves: [MWPW-195301](https://jira.corp.adobe.com/browse/MWPW-195301)

**Test URLs** (the before/after pair the harness visually verified):
- Before: https://main--mas-pinata--adobecom.aem.page/web-components/docs/merch-card.html?martech=off
- After: <!-- no verified visual evidence this run — see the run dashboard -->
