### PR TITLE
test: stabilize flaky studio/web-components suites; make runner ports, concurrency, and timeout configurable

### DIFF
--- a/ost/web-test-runner.config.js
+++ b/ost/web-test-runner.config.js
@@ -12,6 +12,11 @@ export default {
             timeout: Number(process.env.WTR_TEST_TIMEOUT ?? 5000),
         },
     },
+    // Duration telemetry: the console reporter only prints the aggregate suite
+    // duration, not per-test timings. If a specific test starts tripping this
+    // timeout under load again, run it standalone with a JSON/duration-capable
+    // reporter to see which test is slow instead of guessing from the aggregate
+    // number.
     plugins: [esbuildPlugin({ js: true, define: { 'process.env.NODE_ENV': '"production"' } })],
     testRunnerHtml: (testFramework) =>
         `<html>

--- a/ost/web-test-runner.config.js
+++ b/ost/web-test-runner.config.js
@@ -3,6 +3,15 @@ import { esbuildPlugin } from '@web/dev-server-esbuild';
 export default {
     files: 'test/**/*.test.js',
     nodeResolve: true,
+    // Distinct from studio's and web-components' default ports so all runners can
+    // coexist locally.
+    port: Number(process.env.WTR_PORT_OST ?? 18205),
+    concurrency: Number(process.env.WTR_CONCURRENCY ?? 2),
+    testFramework: {
+        config: {
+            timeout: Number(process.env.WTR_TEST_TIMEOUT ?? 5000),
+        },
+    },
     plugins: [esbuildPlugin({ js: true, define: { 'process.env.NODE_ENV': '"production"' } })],
     testRunnerHtml: (testFramework) =>
         `<html>

--- a/studio/test/editors/mas-compare-chart-editor.test.html
+++ b/studio/test/editors/mas-compare-chart-editor.test.html
@@ -285,6 +285,11 @@
                         await el.updateComplete;
                         let chart;
                         for (let i = 0; i < 10; i += 1) {
+                            // Without awaiting updateComplete here, nothing yields to let el's
+                            // render cycle progress, so every iteration reads the same stale
+                            // state - this only "passed" by luck when prior awaits happened to
+                            // leave the DOM already settled.
+                            await el.updateComplete;
                             chart = el.querySelector('[slot="compare-chart-preview"] mas-compare-chart');
                             if (chart?.querySelector(':scope > aem-fragment')) break;
                         }

--- a/studio/test/editors/merch-card-collection-editor.test.html
+++ b/studio/test/editors/merch-card-collection-editor.test.html
@@ -64,6 +64,14 @@
                         editor.fragmentStore = new FragmentStore(new Fragment(collectionFragment));
                         document.querySelector('main sp-theme').appendChild(editor);
                         await editor.updateComplete;
+                        // update() kicks off initFragmentReferencesMap() fire-and-forget; it does
+                        // its own async fragment-cache lookups and calls requestUpdate() when it
+                        // resolves, so a single updateComplete can settle before that work (and the
+                        // re-render it triggers) is done. Await it directly, then flush the render
+                        // it schedules, before asserting/tearing down so nothing bleeds into the
+                        // next test.
+                        await editor.initFragmentReferencesMap();
+                        await editor.updateComplete;
                         expect(editor).to.exist;
                         editor.remove();
                     });

--- a/studio/test/mas-side-nav.test.js
+++ b/studio/test/mas-side-nav.test.js
@@ -1100,16 +1100,23 @@ describe('MasSideNav – Copy Field', () => {
     describe('updateVariationLoadingState', () => {
         let contextStore;
         let contextIsVariationStub;
+        let appendedNodes;
 
         beforeEach(() => {
             contextStore = Store.fragmentEditor.editorContext;
             contextIsVariationStub = sandbox.stub(contextStore, 'isVariation').returns(false);
             contextStore.parentFetchPromise = null;
+            appendedNodes = [];
         });
 
         afterEach(() => {
             contextStore.parentFetchPromise = null;
             contextIsVariationStub.restore();
+            // Tests below append `el` (plus a synthetic editor host) to document.body; if an
+            // assertion throws before their manual .remove() calls, those nodes - and el's live
+            // Store subscriptions - would otherwise linger for the rest of the file's tests.
+            appendedNodes.forEach((node) => node.remove());
+            appendedNodes = [];
         });
 
         it('should resolve and cache price preview when merch-card dispatches mas:ready', async () => {
@@ -1118,6 +1125,7 @@ describe('MasSideNav – Copy Field', () => {
             const card = document.createElement('merch-card');
             editor.append(card);
             document.body.append(el, editor);
+            appendedNodes.push(el, editor);
 
             const price = document.createElement('span');
             price.setAttribute('is', 'inline-price');
@@ -1144,6 +1152,7 @@ describe('MasSideNav – Copy Field', () => {
             const card = document.createElement('merch-card');
             editor.append(card);
             document.body.append(el, editor);
+            appendedNodes.push(el, editor);
 
             const unresolved = document.createElement('span');
             unresolved.setAttribute('is', 'inline-price');
@@ -1168,6 +1177,7 @@ describe('MasSideNav – Copy Field', () => {
             const editor = document.createElement('div');
             editor.fragment = { id: 'frag-123' };
             document.body.append(el, editor);
+            appendedNodes.push(el, editor);
 
             let currentCard = null;
             sandbox.stub(editor, 'querySelector').callsFake((selector) => (selector === 'merch-card' ? currentCard : null));

--- a/studio/test/promotions/mas-promotions-items-table.test.js
+++ b/studio/test/promotions/mas-promotions-items-table.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { html, LitElement } from 'lit';
-import { fixture, fixtureCleanup } from '@open-wc/testing-helpers/pure';
+import { fixture, fixtureCleanup, waitUntil } from '@open-wc/testing-helpers/pure';
 import sinon from 'sinon';
 import Store from '../../src/store.js';
 import { setItemsSelectionStore } from '../../src/common/items-selection-store.js';
@@ -993,7 +993,10 @@ describe('MasPromotionsItemsTable', () => {
             const row = selectItemsTable.shadowRoot.querySelector('mas-collapsible-table-row');
             await row.updateComplete;
             findCreateMenuItem(el).dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
-            await new Promise((r) => setTimeout(r, 20));
+            // #createPromoVariation flips createPromoVariationLoading synchronously before its
+            // first await, so polling it (rather than sleeping a guessed duration) tracks the
+            // real completion of the promo-variation lookup that populates the dialog state.
+            await waitUntil(() => !el.createPromoVariationLoading, 'promo variation lookup did not settle');
             await el.updateComplete;
         };
 
@@ -1199,7 +1202,14 @@ describe('MasPromotionsItemsTable', () => {
             }));
             document.body.appendChild(el);
             await el.updateComplete;
-            await new Promise((r) => setTimeout(r, 80));
+            // #syncExistingPromoVariations runs fire-and-forget off updated() and sets this map
+            // as its very last step, so its presence for defaultPath is the real signal that the
+            // sibling-variation probe (and the geos it derives) has finished, instead of guessing
+            // how long the async AEM lookups take.
+            await waitUntil(
+                () => el.existingPromoVariationGeosByPath.has(defaultPath),
+                'existing promo variation sync did not complete',
+            );
             await el.updateComplete;
             const selectItemsTable = el.shadowRoot.querySelector('mas-select-items-table');
             await selectItemsTable.updateComplete;

--- a/studio/web-test-runner.config.mjs
+++ b/studio/web-test-runner.config.mjs
@@ -59,11 +59,16 @@ export default {
         }),
     ],
     nodeResolve: true,
-    // Distinct from web-components' 2023 so both runners can coexist locally.
-    port: 2024,
+    // Moved off port 2024: that overlaps a port the harness engine's own local
+    // services use, which caused a real shadowing incident (2026-07-30). 18203-18205
+    // is an adjacent, currently-unclaimed range (web-components=18203, studio=18204,
+    // ost=18205); override with WTR_PORT_STUDIO if it collides with something else.
+    port: Number(process.env.WTR_PORT_STUDIO ?? 18204),
+    concurrency: Number(process.env.WTR_CONCURRENCY ?? 2),
     testFramework: {
         config: {
-            timeout: 5000,
+            // Keep the default tight in CI; loaded dev boxes can raise it via WTR_TEST_TIMEOUT.
+            timeout: Number(process.env.WTR_TEST_TIMEOUT ?? 5000),
         },
     },
     testRunnerHtml,

--- a/studio/web-test-runner.config.mjs
+++ b/studio/web-test-runner.config.mjs
@@ -71,5 +71,10 @@ export default {
             timeout: Number(process.env.WTR_TEST_TIMEOUT ?? 5000),
         },
     },
+    // Duration telemetry: the console reporter only prints the aggregate suite
+    // duration, not per-test timings. If a specific test starts tripping this
+    // timeout under load again, run it standalone with a JSON/duration-capable
+    // reporter (or Mocha's --reporter json equivalent) to see which test is slow
+    // instead of guessing from the aggregate number.
     testRunnerHtml,
 };

--- a/web-components/test/merch-offer-select.test.html.js
+++ b/web-components/test/merch-offer-select.test.html.js
@@ -4,7 +4,7 @@ import { expect } from '@esm-bundle/chai';
 import { mockLana } from './mocks/lana.js';
 import { mockFetch } from './mocks/fetch.js';
 
-import { delay, toggleMobile, toggleDesktop } from './utils.js';
+import { delay, toggleMobile, toggleDesktop, waitUntil } from './utils.js';
 import { withWcs } from './mocks/wcs.js';
 import '../src/mas.js';
 
@@ -50,7 +50,13 @@ runTests(async () => {
     describe('merch-offer-select web component', async () => {
         it('should exist, autoselect first offer and render price and cta', async () => {
             const { merchCard, merchOfferSelect } = await renderCard('card1');
-            await delay(200);
+            // Price text comes from each merch-offer's own inline-price element
+            // resolving its (mocked) WCS fetch and rendering, which isn't captured
+            // by merchOfferSelect's updateComplete. Poll for it instead of guessing
+            // how long that takes.
+            await waitUntil(
+                () => getDynamicElements(merchCard, merchOfferSelect).price?.innerText,
+            );
             const { price, cta, description, badge } = getDynamicElements(
                 merchCard,
                 merchOfferSelect,
@@ -158,12 +164,25 @@ runTests(async () => {
         });
 
         it('should update price, cta', async () => {
-            const { merchCard, merchOfferSelect, pickerButton, options } =
-                await renderCard('card2');
+            const {
+                merchCard,
+                merchOfferSelect,
+                merchQuantitySelect,
+                pickerButton,
+                options,
+            } = await renderCard('card2');
             pickerButton.click();
-            await delay(100);
+            // toggleMenu() flips the `closed` property synchronously; wait for the
+            // resulting re-render instead of a fixed delay before targeting an option.
+            await merchQuantitySelect.updateComplete;
             options[2].click();
-            await delay(100);
+            // Selecting a quantity re-syncs price/cta from the matching offer; wait for
+            // the price to actually reach the new value rather than sleeping a guess.
+            await waitUntil(
+                () =>
+                    getDynamicElements(merchCard, merchOfferSelect).price
+                        ?.innerText === 'US$82.49/mo',
+            );
             const { price, cta } = getDynamicElements(
                 merchCard,
                 merchOfferSelect,

--- a/web-components/test/merch-offer-select.test.html.js
+++ b/web-components/test/merch-offer-select.test.html.js
@@ -164,17 +164,10 @@ runTests(async () => {
         });
 
         it('should update price, cta', async () => {
-            const {
-                merchCard,
-                merchOfferSelect,
-                merchQuantitySelect,
-                pickerButton,
-                options,
-            } = await renderCard('card2');
+            const { merchCard, merchOfferSelect, pickerButton, options } =
+                await renderCard('card2');
             pickerButton.click();
-            // toggleMenu() flips the `closed` property synchronously; wait for the
-            // resulting re-render instead of a fixed delay before targeting an option.
-            await merchQuantitySelect.updateComplete;
+            await delay(100);
             options[2].click();
             // Selecting a quantity re-syncs price/cta from the matching offer; wait for
             // the price to actually reach the new value rather than sleeping a guess.

--- a/web-components/test/utils.js
+++ b/web-components/test/utils.js
@@ -6,6 +6,24 @@ window.masPriceLiterals = priceLiteralsJson.data;
 export const delay = (ms = 0) =>
     new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Polls a predicate until it returns a truthy value instead of sleeping a guessed
+ * duration. Useful for waiting on rendering that happens outside a single
+ * updateComplete cycle (e.g. a descendant custom element's own async work).
+ */
+export const waitUntil = async (predicate, { timeout = 2000, interval = 20 } = {}) => {
+    const start = Date.now();
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const result = await predicate();
+        if (result) return result;
+        if (Date.now() - start >= timeout) {
+            throw new Error('waitUntil timed out');
+        }
+        await delay(interval);
+    }
+};
+
 export const keyDown = async (key) => {
     document.activeElement.dispatchEvent(
         new KeyboardEvent('keydown', {

--- a/web-components/web-test-runner.config.mjs
+++ b/web-components/web-test-runner.config.mjs
@@ -34,7 +34,8 @@ export default {
     },
     testFramework: {
         config: {
-            timeout: 10000, // timeout in milliseconds
+            // timeout in milliseconds; override with WTR_TEST_TIMEOUT on loaded dev boxes.
+            timeout: Number(process.env.WTR_TEST_TIMEOUT ?? 10000),
         },
     },
     plugins: [
@@ -49,7 +50,9 @@ export default {
             },
         }),
     ],
-    port: 2023,
+    // Distinct from studio's and ost's default ports so all runners can coexist locally.
+    port: Number(process.env.WTR_PORT_WC ?? 18203),
+    concurrency: Number(process.env.WTR_CONCURRENCY ?? 2),
     reporters: [
         defaultReporter({ reportTestResults: true, reportTestProgress: true }),
     ],

--- a/web-components/web-test-runner.config.mjs
+++ b/web-components/web-test-runner.config.mjs
@@ -38,6 +38,11 @@ export default {
             timeout: Number(process.env.WTR_TEST_TIMEOUT ?? 10000),
         },
     },
+    // Duration telemetry: the console reporter only prints the aggregate suite
+    // duration, not per-test timings. If a specific test starts tripping this
+    // timeout under load again, run it standalone with a JSON/duration-capable
+    // reporter to see which test is slow instead of guessing from the aggregate
+    // number.
     plugins: [
         importMapsPlugin({
             inject: {


### PR DESCRIPTION
## Why

Full `npm test` runs are flaky under load: across four independent runs it failed on a *different* test each time (`mas-side-nav`, `mas-promotions-items-table`, `merch-offer-select`, `merch-card-collection-editor`, `mas-compare-chart-editor`) while a clean-base control run reproduced a fifth unrelated failure with no diff applied at all. Every failure traced to timing assumptions — fixed `setTimeout` sleeps, missing `updateComplete` awaits, or leaked DOM/store state — not to product regressions.

Separately, studio's test runner was pinned to port 2024, which collides with local harness tooling on the same machine and caused a confirmed request-shadowing incident on 2026-07-30.

## What

**Test stabilization — replace timing guesses with real readiness signals:**
- `mas-promotions-items-table.test.js`: poll `createPromoVariationLoading` / `existingPromoVariationGeosByPath` instead of fixed 20/80 ms sleeps (the shared `clickCreateAndWaitForDialog` helper and the pznTags legacy-variation test).
- `merch-offer-select.test.html.js`: poll for `price.innerText` instead of fixed 200/100 ms delays; adds a small local bounded `waitUntil` helper to `test/utils.js`.
- `merch-card-collection-editor.test.html`: the render test now awaits `initFragmentReferencesMap()` — previously fire-and-forget, so teardown raced its `requestUpdate`.
- `mas-side-nav.test.js`: tracked-node `afterEach` cleanup — three tests appended elements to `document.body` with manual `.remove()` that was skipped whenever an assertion threw, leaking DOM nodes and live store subscriptions into later tests.
- `mas-compare-chart-editor.test.html`: the preview polling loop had no `await` inside it (a synchronous busy-loop that could never observe a state change); it now awaits the render cycle per iteration.

**Runner configuration:**
- Dev ports move off 2023/2024 to 18203 (web-components) / 18204 (studio) / 18205 (ost), each overridable via `WTR_PORT_*`. This is a deliberate behavior change, documented in the commit: 2024 overlaps local harness services and caused the shadowing incident above.
- `WTR_CONCURRENCY` (default 2) bounds parallel browser instances; `WTR_TEST_TIMEOUT` gates the per-test timeout with unchanged defaults (studio 5000 ms, web-components 10000 ms), so CI keeps its tight signal while loaded dev machines can raise it.

## Verification

Every touched test file passed three consecutive standalone runs on isolated ports, and the config defaults were re-verified binding cleanly with all env vars unset (68/68 side-nav, 65/65 promotions, 12/12 collection editor, 6/6 compare chart, 10/10 offer select).

## Known issue deliberately not "fixed"

`merch-offer-select`'s quantity-selector test keeps one pre-click `delay(100)`: replacing it with `updateComplete` exposes a reproducible race where the component's async initial-offer-selection overwrites a user's quantity click that lands too early (`data-quantity` stuck at the old value, 3/3 runs). That looks like a real product bug rather than test flakiness and deserves its own ticket instead of a test that hides it.

Note for anyone re-running: `test/merch-offer-select.test.html.js` is not a standalone entry point — run it via `test/merch-offer-select.test.html`, which provides the template fixtures.
