### PR TITLE
Wait for the SUSI form before the first ims fill

### DIFF
--- a/.pinata/preview.yaml
+++ b/.pinata/preview.yaml
@@ -78,6 +78,15 @@ auth_profiles:
             password_env: IMS_PASS
         idp_hosts: [auth.services.adobe.com, ims-na1.adobelogin.com]
         steps:
+            # Studio signs in via a client-side imslib redirect: the page is
+            # still on its own origin when the steps start, and the fill guard
+            # (rightly) refuses to type credentials off the idp hosts. Wait
+            # for the SUSI form to exist so the redirect has landed before the
+            # first fill. Optional: server-redirecting hosts are already past
+            # this, and a silent-SSO session never shows the form at all.
+            - wait_for: '#EmailPage-EmailField'
+              optional: true
+              timeout_ms: 60000
             - fill: '#EmailPage-EmailField'
               value_from: username
               timeout_ms: 45000


### PR DESCRIPTION
Run 818eda4a proved the `studio-content` surface works up to auth: the capture selected the surface, served the worktree, and started the ims login — then the fill guard refused with *"refusing to fill '#EmailPage-EmailField' on 'localhost'"*.

Root cause is a time-of-check race, not a bad host: the guard reads the page host **before** the fill's own selector wait. Hosts that 302 server-side (milo previews, admin.hlx.page mints) are already on the IdP when steps start; Studio redirects **client-side** (imslib loads → `validateToken` fails → `adobeIMS.signIn()`), so the steps begin while the page is still on localhost.

Fix: an optional `wait_for: '#EmailPage-EmailField'` (60s) ahead of the first fill. The redirect lands, then the guard sees `auth.services.adobe.com` and passes. Server-redirecting hosts skip straight through (the field already exists), and silent-SSO sessions — which never render the form — swallow the timeout instead of failing, so the da-cc/da-dc mint flows can't regress.