### PR TITLE
Pin Studio captures to the stage environment

### DIFF
--- a/.pinata/preview.yaml
+++ b/.pinata/preview.yaml
@@ -206,14 +206,14 @@ surfaces:
     # M@S Studio, a hash-routed app on studio.html. mas.adobe.com is an own
     # host, so the capture serves the diff-applied worktree with the author
     # proxy on stage (never production content); the ims login rides the
-    # mas.adobe.com capture-host entry. nala is the e2e suite's content
+    # mas.adobe.com capture-host entry. sandbox is the designated testing
     # folder, so the grid always has real cards to open.
     # aem.env=stage repeated here so NON-local rungs (branch preview) also pin
     # Studio to the stage author instead of its prod default.
     - id: studio-content
-      url: https://mas.adobe.com/studio.html?aem.env=stage#page=content&path=nala
+      url: https://mas.adobe.com/studio.html?aem.env=stage#page=content&path=sandbox
       description: >-
-          M@S Studio authoring app on the content grid of the nala folder,
+          M@S Studio authoring app on the content grid of the sandbox folder,
           real stage cards. Double-clicking a card opens the merch card
           editor and its fields: tag pickers, prices, OST links, variant
           controls. Pick for any studio/ change — editors, fields, dialogs,

--- a/.pinata/preview.yaml
+++ b/.pinata/preview.yaml
@@ -21,7 +21,12 @@ local:
     # view rendering an empty list, which photographs as real evidence.
     cmd: 'PROXY_PORT=8091 npm --prefix studio run proxy:stage & until curl -s -o /dev/null -X OPTIONS http://127.0.0.1:8091/; do sleep 0.5; done; aem up --port=3000 --no-open --stop-other --url https://main--mas--adobecom.aem.page'
     # proxy.port tells studio.html which author proxy to call; galleries ignore it.
-    url: 'http://localhost:3000{page}?proxy.port=8091'
+    # aem.env=stage pins Studio's WHOLE environment to stage: locally the author
+    # already rides the stage proxy, but the mas-studio IO runtime would default
+    # to prod without it. Base params override a pasted link's own aem.env, so
+    # automated captures are stage-pinned deterministically; non-Studio pages
+    # ignore the param.
+    url: 'http://localhost:3000{page}?proxy.port=8091&aem.env=stage'
     # Foreign consumer pages stay remote on the public content host and pull
     # web components from this server via maslibs=local. studio.html is listed as
     # an own host instead: it loads its code by relative path, so only serving it
@@ -203,8 +208,10 @@ surfaces:
     # proxy on stage (never production content); the ims login rides the
     # mas.adobe.com capture-host entry. nala is the e2e suite's content
     # folder, so the grid always has real cards to open.
+    # aem.env=stage repeated here so NON-local rungs (branch preview) also pin
+    # Studio to the stage author instead of its prod default.
     - id: studio-content
-      url: https://mas.adobe.com/studio.html#page=content&path=nala
+      url: https://mas.adobe.com/studio.html?aem.env=stage#page=content&path=nala
       description: >-
           M@S Studio authoring app on the content grid of the nala folder,
           real stage cards. Double-clicking a card opens the merch card


### PR DESCRIPTION
Per operator direction: every MAS Studio test/capture should run against stage, declared in the tenant contract — and the Studio surface now uses the **sandbox** folder (designated testing content) instead of nala.

`studio.html` derives two backends from its URL: the author (locally already stage via the `proxy:stage` author proxy) and the mas-studio IO runtime, which **defaults to prod when `aem.env` is absent** — so captures were mixing the stage author with prod IO services. On a non-local rung (branch preview, `isLocal=false`) a missing `aem.env` would point Studio at the **prod author** outright.

Changes, engine-parser-verified:
- `local.url` now carries `aem.env=stage` — covers every locally served capture, including requester-pasted Studio deep links (base params override a pasted link's own `aem.env`); non-Studio pages ignore the param.
- The `studio-content` surface url repeats it for non-local rungs.
- `studio-content` targets `path=sandbox`.

Composed capture URL: `http://localhost:3000/studio.html?proxy.port=8091&aem.env=stage#page=content&path=sandbox`.