### PR TITLE
Publish the preview branch at verification time

### DIFF
--- a/.pinata/preview.yaml
+++ b/.pinata/preview.yaml
@@ -20,6 +20,10 @@ local:
     # proxy that never binds would otherwise leave aem up healthy and the promotions
     # view rendering an empty list, which photographs as real evidence.
     cmd: 'PROXY_PORT=8091 npm --prefix studio run proxy:stage & until curl -s -o /dev/null -X OPTIONS http://127.0.0.1:8091/; do sleep 0.5; done; aem up --port=3000 --no-open --stop-other --url https://main--mas--adobecom.aem.page'
+    # Push the Close branch at verification time too, so the share URL a human
+    # sees at escalation (and in the PR body) resolves instead of 404ing until
+    # approval. The gate's share_sync probe vouches for propagation.
+    publish_branch: true
     # proxy.port tells studio.html which author proxy to call; galleries ignore it.
     # aem.env=stage pins Studio's WHOLE environment to stage: locally the author
     # already rides the stage proxy, but the mas-studio IO runtime would default


### PR DESCRIPTION
Companion to engine `6ab4672`: the operator clicked the Test URL at escalation time and got a 404 because the branch only exists once Close pushes it.

`local.publish_branch: true` opts this contract into the engine's new early push: LOCAL-mode verification pushes the same branch Close will push (same fork-target policy), so the share link resolves by the time a human sees it. The visual gate now records a `share_sync` verdict (byte-equality probe against the pin host) and the dashboard labels a not-yet-synced link instead of handing out a silent 404. Evals and the env-var operator fallback never push — the flag is contract-scoped opt-in, engine-parser-validated.