### PR TITLE
[fiesta] MWPW-202902: [M@S Usability] reveal user email for version history in M@S Studio (cuirrently "workflow-service")

### DIFF
--- a/studio/src/version-page.js
+++ b/studio/src/version-page.js
@@ -219,6 +219,21 @@ class VersionPage extends LitElement {
             font-size: 18px;
             margin-bottom: 8px;
         }
+        .version-author-email {
+            display: block;
+            font-size: 13px;
+            color: #6e6e6e;
+            word-break: break-all;
+        }
+        .version-published-by {
+            font-size: 13px;
+            color: #494949;
+            margin-top: 6px;
+        }
+        .version-published-by .version-author-name {
+            font-size: 13px;
+            margin-bottom: 0;
+        }
 
         .version-description {
             font-size: 13px;
@@ -604,6 +619,40 @@ class VersionPage extends LitElement {
         return `${day} ${month}, ${year} at ${time}`;
     }
 
+    /**
+     * AEM records the user id, which for Studio authors is their email. Prefer a human name when one
+     * is available — from the audit entry, or from the loaded directory — and fall back to the id so
+     * the attribution is never blank.
+     */
+    resolveUserName(userId, fullName) {
+        if (fullName) return fullName;
+        if (!userId) return 'Unknown';
+        const user = Store.users.get().find((u) => u.userPrincipalName?.toLowerCase() === userId.toLowerCase());
+        return user?.displayName || userId;
+    }
+
+    /** The email is only worth revealing alongside a name that isn't already the email itself. */
+    resolveUserEmail(userId, displayedName) {
+        if (!userId || userId === displayedName) return '';
+        return userId;
+    }
+
+    authorName(version) {
+        return this.resolveUserName(version.createdBy, version.createdByName);
+    }
+
+    authorEmail(version) {
+        return this.resolveUserEmail(version.createdBy, this.authorName(version));
+    }
+
+    publisherName(version) {
+        return this.resolveUserName(version.publishedBy, version.publishedByName);
+    }
+
+    publisherEmail(version) {
+        return this.resolveUserEmail(version.publishedBy, this.publisherName(version));
+    }
+
     get versionListPanel() {
         return html`
             <div class="version-list-panel">
@@ -650,8 +699,20 @@ class VersionPage extends LitElement {
                                 <sp-icon-calendar slot="icon"></sp-icon-calendar>${this.formatVersionDate(version.created)}
                             </div>
                             <div class="version-author">
-                                By <span class="version-author-name">${version.createdBy || 'Unknown'}</span>
+                                By <span class="version-author-name">${this.authorName(version)}</span>
+                                ${this.authorEmail(version)
+                                    ? html`<span class="version-author-email">${this.authorEmail(version)}</span>`
+                                    : nothing}
                             </div>
+                            ${version.publishedBy
+                                ? html`<div class="version-published-by">
+                                      Published by
+                                      <span class="version-author-name">${this.publisherName(version)}</span>
+                                      ${this.publisherEmail(version)
+                                          ? html`<span class="version-author-email">${this.publisherEmail(version)}</span>`
+                                          : nothing}
+                                  </div>`
+                                : nothing}
                             ${version.title
                                 ? html`<div class="version-description"><strong>${version.title}</strong></div>`
                                 : nothing}

--- a/studio/src/version-repository.js
+++ b/studio/src/version-repository.js
@@ -1,6 +1,63 @@
 import Events from './events.js';
 
 /**
+ * Publishing goes through an AEM activation workflow, so AEM stamps the publish audit trail with
+ * the workflow's own service account instead of the author who triggered it. Version history has to
+ * recognise those accounts to avoid presenting them as authors.
+ */
+const SYSTEM_ACCOUNTS = new Set(['workflow-process-service', 'workflow-service', 'workflow-user', 'system', 'admin']);
+
+/**
+ * @param {string} [userId] - User id recorded by AEM
+ * @returns {boolean} Whether the id belongs to a system account rather than an author
+ */
+export function isSystemAccount(userId) {
+    if (!userId) return false;
+    return SYSTEM_ACCOUNTS.has(`${userId}`.trim().toLowerCase());
+}
+
+/**
+ * AEM reports audit metadata either nested (`modified: { at, by, fullName }`) or flattened
+ * (`modifiedBy`), depending on the endpoint. Read either shape into one.
+ * @param {Object|string} [entry] - Nested audit entry, or a bare timestamp
+ * @param {string} [flatBy] - User id from the flattened form
+ * @returns {{ at: string|undefined, by: string|undefined, fullName: string|undefined }}
+ */
+export function readAudit(entry, flatBy) {
+    if (entry && typeof entry === 'object') {
+        return { at: entry.at, by: entry.by ?? flatBy, fullName: entry.fullName };
+    }
+    return { at: typeof entry === 'string' ? entry : undefined, by: flatBy, fullName: undefined };
+}
+
+/** @returns {boolean} Whether `at` is a valid timestamp no later than `limit` */
+function isNotNewerThan(at, limit) {
+    const time = Date.parse(at);
+    const limitTime = Date.parse(limit);
+    if (Number.isNaN(time) || Number.isNaN(limitTime)) return false;
+    return time <= limitTime;
+}
+
+/**
+ * Resolve the author behind an audited action. A system account means AEM recorded the workflow
+ * instead of the user who triggered it; the author is then the user whose content modification the
+ * workflow acted on. That substitution is only trusted when the modification is not newer than the
+ * action, so a later edit is never credited with an earlier publish.
+ * @param {{ at: string|undefined, by: string|undefined, fullName: string|undefined }} action
+ * @param {{ at: string|undefined, by: string|undefined, fullName: string|undefined }} [modification]
+ * @returns {{ by: string|undefined, fullName: string|undefined, system: boolean }}
+ */
+export function resolveActor(action, modification) {
+    if (action.by && !isSystemAccount(action.by)) {
+        return { by: action.by, fullName: action.fullName, system: false };
+    }
+    if (modification?.by && !isSystemAccount(modification.by) && isNotNewerThan(modification.at, action.at)) {
+        return { by: modification.by, fullName: modification.fullName, system: false };
+    }
+    return { by: action.by, fullName: action.fullName, system: true };
+}
+
+/**
  * Repository for version-related data operations.
  * Handles loading, saving, and restoring fragment versions.
  */
@@ -20,31 +77,26 @@ export class VersionRepository {
             const fragment = await this.repository.aem.sites.cf.fragments.getById(fragmentId);
 
             // Create a "current version" from the live fragment
-            // Handle different formats of modified date (could be string, object with 'at' property, or undefined)
-            let modifiedDate;
-            if (fragment.modified) {
-                if (typeof fragment.modified === 'object' && fragment.modified.at) {
-                    modifiedDate = fragment.modified.at;
-                } else if (typeof fragment.modified === 'string') {
-                    modifiedDate = fragment.modified;
-                } else {
-                    modifiedDate = new Date().toISOString();
-                }
-            } else {
-                modifiedDate = new Date().toISOString();
-            }
+            const modified = readAudit(fragment.modified, fragment.modifiedBy);
+            const published = readAudit(fragment.published, fragment.publishedBy);
+            const modifiedActor = resolveActor(modified, modified);
+            const publishedActor = resolveActor(published, modified);
 
             const currentVersion = {
                 id: 'current',
                 version: 'Current',
-                created: modifiedDate,
-                createdBy: fragment.modifiedBy || fragment.modified?.by || 'System',
+                created: modified.at || new Date().toISOString(),
+                createdBy: modifiedActor.by || 'System',
+                createdByName: modifiedActor.fullName,
+                publishedAt: published.at,
+                publishedBy: published.at ? publishedActor.by : undefined,
+                publishedByName: published.at ? publishedActor.fullName : undefined,
                 isCurrent: true,
             };
 
             // Load version history
             const versionsResponse = await this.repository.aem.sites.cf.fragments.getVersions(fragmentId);
-            const historicalVersions = versionsResponse?.items || [];
+            const historicalVersions = (versionsResponse?.items || []).map((version) => this.normalizeVersion(version));
 
             // Combine current version with historical versions
             const versions = [currentVersion, ...historicalVersions];
@@ -58,6 +110,25 @@ export class VersionRepository {
             console.error('Failed to load version history:', error);
             throw error;
         }
+    }
+
+    /**
+     * Normalize a historical version so authorship reads the same as the current version, whichever
+     * audit shape AEM returned and whether or not a workflow account created the version.
+     * @param {Object} version - Raw version item from AEM
+     * @returns {Object} Version with `created`, `createdBy` and `createdByName` resolved
+     */
+    normalizeVersion(version) {
+        const created = readAudit(version.created, version.createdBy);
+        const modified = readAudit(version.modified, version.modifiedBy);
+        const actor = resolveActor(created, modified);
+
+        return {
+            ...version,
+            created: created.at ?? version.created,
+            createdBy: actor.by,
+            createdByName: actor.fullName,
+        };
     }
 
     /**
@@ -148,6 +219,9 @@ export class VersionRepository {
             return (
                 version.version?.toLowerCase().includes(lowerQuery) ||
                 version.createdBy?.toLowerCase().includes(lowerQuery) ||
+                version.createdByName?.toLowerCase().includes(lowerQuery) ||
+                version.publishedBy?.toLowerCase().includes(lowerQuery) ||
+                version.publishedByName?.toLowerCase().includes(lowerQuery) ||
                 version.created?.toLowerCase().includes(lowerQuery) ||
                 version.comment?.toLowerCase().includes(lowerQuery)
             );

--- a/studio/test/version-page.test.html
+++ b/studio/test/version-page.test.html
@@ -310,6 +310,94 @@
                             expect(versionPage.hydratedCards).to.be.an.instanceof(Set);
                         });
                     });
+
+                    describe('author attribution', () => {
+                        beforeEach(async () => {
+                            versionPage = await fixture(html`<version-page></version-page>`);
+                            await versionPage.updateComplete;
+                            Store.users.set([]);
+                        });
+
+                        afterEach(() => {
+                            Store.users.set([]);
+                        });
+
+                        it('should prefer the full name recorded by AEM', () => {
+                            const version = { createdBy: 'alice@example.com', createdByName: 'Alice Smith' };
+                            expect(versionPage.authorName(version)).to.equal('Alice Smith');
+                            expect(versionPage.authorEmail(version)).to.equal('alice@example.com');
+                        });
+
+                        it('should resolve the display name from the loaded users', () => {
+                            Store.users.set([{ userPrincipalName: 'Alice@Example.com', displayName: 'Alice Smith' }]);
+                            const version = { createdBy: 'alice@example.com' };
+                            expect(versionPage.authorName(version)).to.equal('Alice Smith');
+                            expect(versionPage.authorEmail(version)).to.equal('alice@example.com');
+                        });
+
+                        it('should fall back to the user id and not repeat it as the email', () => {
+                            const version = { createdBy: 'alice@example.com' };
+                            expect(versionPage.authorName(version)).to.equal('alice@example.com');
+                            expect(versionPage.authorEmail(version)).to.equal('');
+                        });
+
+                        it('should report an unknown author when no id is recorded', () => {
+                            expect(versionPage.authorName({})).to.equal('Unknown');
+                            expect(versionPage.authorEmail({})).to.equal('');
+                        });
+
+                        it('should resolve the publisher the same way', () => {
+                            Store.users.set([{ userPrincipalName: 'bob@example.com', displayName: 'Bob Jones' }]);
+                            const version = { publishedBy: 'bob@example.com' };
+                            expect(versionPage.publisherName(version)).to.equal('Bob Jones');
+                            expect(versionPage.publisherEmail(version)).to.equal('bob@example.com');
+                        });
+
+                        it('should render the author email and publisher in the version list', async () => {
+                            versionPage.versions = [
+                                {
+                                    id: 'current',
+                                    version: 'Current',
+                                    created: '2024-01-15T10:00:00Z',
+                                    createdBy: 'alice@example.com',
+                                    createdByName: 'Alice Smith',
+                                    publishedBy: 'bob@example.com',
+                                    publishedByName: 'Bob Jones',
+                                    isCurrent: true,
+                                },
+                            ];
+                            Store.page.set('version');
+                            versionPage.requestUpdate();
+                            await versionPage.updateComplete;
+
+                            const emails = [...versionPage.querySelectorAll('.version-author-email')].map((el) =>
+                                el.textContent.trim(),
+                            );
+                            expect(emails).to.include('alice@example.com');
+                            expect(emails).to.include('bob@example.com');
+
+                            const publishedBy = versionPage.querySelector('.version-published-by');
+                            expect(publishedBy).to.exist;
+                            expect(publishedBy.textContent).to.contain('Bob Jones');
+                        });
+
+                        it('should omit publisher attribution when the version was never published', async () => {
+                            versionPage.versions = [
+                                {
+                                    id: 'current',
+                                    version: 'Current',
+                                    created: '2024-01-15T10:00:00Z',
+                                    createdBy: 'alice@example.com',
+                                    isCurrent: true,
+                                },
+                            ];
+                            Store.page.set('version');
+                            versionPage.requestUpdate();
+                            await versionPage.updateComplete;
+
+                            expect(versionPage.querySelector('.version-published-by')).to.not.exist;
+                        });
+                    });
                 });
             });
         </script>

--- a/studio/test/version-repository.test.js
+++ b/studio/test/version-repository.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { VersionRepository } from '../src/version-repository.js';
+import { VersionRepository, isSystemAccount, readAudit, resolveActor } from '../src/version-repository.js';
 import Events from '../src/events.js';
 
 describe('VersionRepository', () => {
@@ -82,6 +82,227 @@ describe('VersionRepository', () => {
 
             expect(result.currentVersion.created).to.be.a('string');
             expect(result.currentVersion.createdBy).to.equal('System');
+        });
+
+        it('should expose the full name alongside the user id when AEM provides it', async () => {
+            const fragment = {
+                id: 'fragment-1',
+                modified: { at: '2024-01-15T10:00:00Z', by: 'alice@example.com', fullName: 'Alice Smith' },
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves({ items: [] });
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.currentVersion.createdBy).to.equal('alice@example.com');
+            expect(result.currentVersion.createdByName).to.equal('Alice Smith');
+        });
+
+        it('should attribute publishing to the triggering user instead of the workflow service account', async () => {
+            const fragment = {
+                id: 'fragment-1',
+                modified: { at: '2024-01-15T10:00:00Z', by: 'alice@example.com', fullName: 'Alice Smith' },
+                published: { at: '2024-01-15T10:05:00Z', by: 'workflow-process-service' },
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves({ items: [] });
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.currentVersion.publishedAt).to.equal('2024-01-15T10:05:00Z');
+            expect(result.currentVersion.publishedBy).to.equal('alice@example.com');
+            expect(result.currentVersion.publishedByName).to.equal('Alice Smith');
+        });
+
+        it('should keep the real publisher when AEM already records a user', async () => {
+            const fragment = {
+                id: 'fragment-1',
+                modified: { at: '2024-01-15T10:00:00Z', by: 'alice@example.com' },
+                published: { at: '2024-01-15T10:05:00Z', by: 'bob@example.com', fullName: 'Bob Jones' },
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves({ items: [] });
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.currentVersion.publishedBy).to.equal('bob@example.com');
+            expect(result.currentVersion.publishedByName).to.equal('Bob Jones');
+        });
+
+        it('should not credit a publish to an edit made after it', async () => {
+            const fragment = {
+                id: 'fragment-1',
+                modified: { at: '2024-01-16T09:00:00Z', by: 'alice@example.com' },
+                published: { at: '2024-01-15T10:05:00Z', by: 'workflow-process-service' },
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves({ items: [] });
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.currentVersion.publishedBy).to.equal('workflow-process-service');
+        });
+
+        it('should leave publish attribution unset when the fragment was never published', async () => {
+            const fragment = {
+                id: 'fragment-1',
+                modified: { at: '2024-01-15T10:00:00Z', by: 'alice@example.com' },
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves({ items: [] });
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.currentVersion.publishedAt).to.be.undefined;
+            expect(result.currentVersion.publishedBy).to.be.undefined;
+        });
+
+        it('should normalize historical versions recorded in the nested audit shape', async () => {
+            const fragment = { id: 'fragment-1', modified: '2024-01-15T10:00:00Z', modifiedBy: 'alice@example.com' };
+            const versionsResponse = {
+                items: [
+                    {
+                        id: 'v1',
+                        version: '1.0',
+                        created: { at: '2024-01-14T10:00:00Z', by: 'bob@example.com', fullName: 'Bob Jones' },
+                    },
+                ],
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves(versionsResponse);
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.versions[1].created).to.equal('2024-01-14T10:00:00Z');
+            expect(result.versions[1].createdBy).to.equal('bob@example.com');
+            expect(result.versions[1].createdByName).to.equal('Bob Jones');
+        });
+
+        it('should attribute a workflow-created version to the user who modified it', async () => {
+            const fragment = { id: 'fragment-1', modified: '2024-01-15T10:00:00Z', modifiedBy: 'alice@example.com' };
+            const versionsResponse = {
+                items: [
+                    {
+                        id: 'v1',
+                        version: '1.0',
+                        created: { at: '2024-01-14T10:05:00Z', by: 'workflow-process-service' },
+                        modified: { at: '2024-01-14T10:00:00Z', by: 'carol@example.com', fullName: 'Carol Ray' },
+                    },
+                ],
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves(versionsResponse);
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.versions[1].createdBy).to.equal('carol@example.com');
+            expect(result.versions[1].createdByName).to.equal('Carol Ray');
+        });
+
+        it('should preserve flat historical version fields', async () => {
+            const fragment = { id: 'fragment-1', modified: '2024-01-15T10:00:00Z', modifiedBy: 'alice@example.com' };
+            const versionsResponse = {
+                items: [{ id: 'v1', version: '1.0', created: '2024-01-14T10:00:00Z', createdBy: 'bob@example.com' }],
+            };
+
+            mockRepository.aem.sites.cf.fragments.getById.resolves(fragment);
+            mockRepository.aem.sites.cf.fragments.getVersions.resolves(versionsResponse);
+
+            const result = await versionRepository.loadVersionHistory('fragment-1');
+
+            expect(result.versions[1].created).to.equal('2024-01-14T10:00:00Z');
+            expect(result.versions[1].createdBy).to.equal('bob@example.com');
+            expect(result.versions[1].createdByName).to.be.undefined;
+        });
+    });
+
+    describe('isSystemAccount', () => {
+        it('should recognize workflow service accounts regardless of casing or padding', () => {
+            expect(isSystemAccount('workflow-process-service')).to.be.true;
+            expect(isSystemAccount('  Workflow-Process-Service ')).to.be.true;
+            expect(isSystemAccount('workflow-service')).to.be.true;
+        });
+
+        it('should not treat real users or missing ids as system accounts', () => {
+            expect(isSystemAccount('alice@example.com')).to.be.false;
+            expect(isSystemAccount(undefined)).to.be.false;
+            expect(isSystemAccount('')).to.be.false;
+        });
+    });
+
+    describe('readAudit', () => {
+        it('should read the nested audit shape', () => {
+            const audit = readAudit({ at: '2024-01-15T10:00:00Z', by: 'alice@example.com', fullName: 'Alice Smith' });
+            expect(audit).to.deep.equal({
+                at: '2024-01-15T10:00:00Z',
+                by: 'alice@example.com',
+                fullName: 'Alice Smith',
+            });
+        });
+
+        it('should read the flattened audit shape', () => {
+            const audit = readAudit('2024-01-15T10:00:00Z', 'alice@example.com');
+            expect(audit.at).to.equal('2024-01-15T10:00:00Z');
+            expect(audit.by).to.equal('alice@example.com');
+            expect(audit.fullName).to.be.undefined;
+        });
+
+        it('should fall back to the flattened user id when the nested entry omits it', () => {
+            const audit = readAudit({ at: '2024-01-15T10:00:00Z' }, 'alice@example.com');
+            expect(audit.by).to.equal('alice@example.com');
+        });
+
+        it('should return an empty audit for missing metadata', () => {
+            expect(readAudit(undefined, undefined)).to.deep.equal({ at: undefined, by: undefined, fullName: undefined });
+        });
+    });
+
+    describe('resolveActor', () => {
+        it('should keep a real user recorded on the action', () => {
+            const actor = resolveActor(
+                { at: '2024-01-15T10:05:00Z', by: 'bob@example.com', fullName: 'Bob Jones' },
+                { at: '2024-01-15T10:00:00Z', by: 'alice@example.com' },
+            );
+            expect(actor).to.deep.equal({ by: 'bob@example.com', fullName: 'Bob Jones', system: false });
+        });
+
+        it('should substitute the modifying user for a system account', () => {
+            const actor = resolveActor(
+                { at: '2024-01-15T10:05:00Z', by: 'workflow-process-service' },
+                { at: '2024-01-15T10:00:00Z', by: 'alice@example.com', fullName: 'Alice Smith' },
+            );
+            expect(actor).to.deep.equal({ by: 'alice@example.com', fullName: 'Alice Smith', system: false });
+        });
+
+        it('should report a system actor when no modification precedes the action', () => {
+            const actor = resolveActor({ at: '2024-01-15T10:05:00Z', by: 'workflow-process-service' }, undefined);
+            expect(actor.by).to.equal('workflow-process-service');
+            expect(actor.system).to.be.true;
+        });
+
+        it('should not substitute another system account', () => {
+            const actor = resolveActor(
+                { at: '2024-01-15T10:05:00Z', by: 'workflow-process-service' },
+                { at: '2024-01-15T10:00:00Z', by: 'admin' },
+            );
+            expect(actor.by).to.equal('workflow-process-service');
+            expect(actor.system).to.be.true;
+        });
+
+        it('should not substitute when timestamps are unusable', () => {
+            const actor = resolveActor(
+                { at: undefined, by: 'workflow-process-service' },
+                { at: '2024-01-15T10:00:00Z', by: 'alice@example.com' },
+            );
+            expect(actor.by).to.equal('workflow-process-service');
+            expect(actor.system).to.be.true;
         });
     });
 
@@ -363,6 +584,19 @@ describe('VersionRepository', () => {
             const result = versionRepository.searchVersions(versions, 'features');
             expect(result).to.have.lengthOf(1);
             expect(result[0].comment).to.include('features');
+        });
+
+        it('should filter by author display name', () => {
+            const named = [...versions, { version: '4.0', createdBy: 'dan@example.com', createdByName: 'Dan Fox' }];
+            const result = versionRepository.searchVersions(named, 'dan fox');
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].version).to.equal('4.0');
+        });
+
+        it('should filter by publisher', () => {
+            const published = [...versions, { version: '4.0', publishedBy: 'erin@example.com', publishedByName: 'Erin Lee' }];
+            expect(versionRepository.searchVersions(published, 'erin@example.com')).to.have.lengthOf(1);
+            expect(versionRepository.searchVersions(published, 'Erin Lee')).to.have.lengthOf(1);
         });
     });
 });


### PR DESCRIPTION
* Now I'll implement. First the repository normalization:
* The implementation is complete and all four runnable gates pass.

Resolves: [MWPW-202902](https://jira.corp.adobe.com/browse/MWPW-202902)

**Test URLs** (the before/after pair the harness visually verified):
- After: https://mwpw-202902--mas-pinata--adobecom.aem.page/studio.html?aem.env=stage&martech=off#page=content&path=sandbox
