### PR TITLE
[fiesta] [M@S Usability] Allow authors to add Product Code tags in Studio

### DIFF
--- a/studio/src/aem/aem-tag-picker-field.js
+++ b/studio/src/aem/aem-tag-picker-field.js
@@ -5,12 +5,13 @@ import {
     AEM_TAG_PATH_PRODUCT_CODE_ROOT,
     COMPARE_CHART_CREATE_TYPE,
     EVENT_OST_OFFER_SELECT,
+    MAS_PRODUCT_CODE_PREFIX,
     TAG_COMPARE_CHART_PATH,
 } from '../constants.js';
 import { isPznCountryTagPath } from '../common/utils/personalization-utils.js';
 import { VARIANTS } from '../editors/variant-picker.js';
 import { getItemFieldState } from '../utils/field-state.js';
-import { getService } from '../utils.js';
+import { getService, showToast, UserFriendlyError } from '../utils.js';
 import { AEM_TAG_PATTERN, fromAttribute, toAttribute } from './tag-path-utils.js';
 import { ensureNamespaceTags, getNamespaceCache } from './tag-cache.js';
 
@@ -63,6 +64,12 @@ class AemTagPickerField extends LitElement {
         disabled: { type: Boolean, reflect: true },
         /** When set, overrides the selection-derived quiet styling of the trigger button. */
         quiet: { type: Boolean },
+        /** When true, shows a "Create product code" button in hierarchical mode. */
+        allowCreate: { type: Boolean, attribute: 'allow-create' },
+        createDialogOpen: { type: Boolean, state: true },
+        createDialogCode: { type: String, state: true },
+        createDialogTitle: { type: String, state: true },
+        createDialogBusy: { type: Boolean, state: true },
     };
 
     static styles = css`
@@ -171,6 +178,13 @@ class AemTagPickerField extends LitElement {
             opacity: 0.45;
             pointer-events: none;
         }
+
+        .create-tag-form {
+            display: flex;
+            flex-direction: column;
+            gap: var(--spectrum-spacing-200);
+            padding-block-end: var(--spectrum-spacing-200);
+        }
     `;
 
     #aem;
@@ -196,6 +210,11 @@ class AemTagPickerField extends LitElement {
         this.personalizationToggle = false;
         this.personalizationEnabled = false;
         this.disabled = false;
+        this.allowCreate = false;
+        this.createDialogOpen = false;
+        this.createDialogCode = '';
+        this.createDialogTitle = '';
+        this.createDialogBusy = false;
     }
 
     async #getOfferProductArrangementCode(offerSelectorId, offer) {
@@ -966,6 +985,89 @@ class AemTagPickerField extends LitElement {
         `;
     }
 
+    #openCreateDialog() {
+        this.createDialogCode = '';
+        this.createDialogTitle = '';
+        this.createDialogBusy = false;
+        this.createDialogOpen = true;
+    }
+
+    #closeCreateDialog() {
+        this.createDialogOpen = false;
+    }
+
+    async #handleCreateTag() {
+        const code = this.createDialogCode.trim().toLowerCase();
+        const title = this.createDialogTitle.trim();
+        if (!code || !title) return;
+
+        const tagPath = `${AEM_TAG_PATH_PRODUCT_CODE_ROOT}/${code}`;
+        this.createDialogBusy = true;
+        try {
+            await this.#aem.tags.create(tagPath, title);
+        } catch (err) {
+            this.createDialogBusy = false;
+            const message = err instanceof UserFriendlyError ? err.message : 'Failed to create product code tag.';
+            showToast(message, 'negative');
+            return;
+        }
+
+        const cache = getNamespaceCache(this.namespace);
+        if (cache) {
+            cache.set(tagPath, { name: code, title, path: tagPath });
+        }
+
+        this.createDialogOpen = false;
+        this.createDialogBusy = false;
+
+        await this.loadTags();
+
+        const tagId = `${MAS_PRODUCT_CODE_PREFIX}${code}`;
+        this.value = this.#normalizeProductCodeTags([...this.#asValueArray(), tagId]);
+        await this.#notifyChange();
+
+        showToast(`Product code tag "${title}" created.`, 'positive');
+    }
+
+    get createDialog() {
+        if (!this.createDialogOpen) return nothing;
+        return html`
+            <sp-dialog-wrapper
+                open
+                underlay
+                headline="Create product code tag"
+                confirm-label="Create"
+                cancel-label="Cancel"
+                ?loading=${this.createDialogBusy}
+                @confirm=${this.#handleCreateTag}
+                @cancel=${this.#closeCreateDialog}
+            >
+                <div class="create-tag-form">
+                    <sp-field-label for="create-code">Product code</sp-field-label>
+                    <sp-textfield
+                        id="create-code"
+                        placeholder="e.g. acrobat"
+                        .value=${this.createDialogCode}
+                        ?disabled=${this.createDialogBusy}
+                        @input=${(e) => {
+                            this.createDialogCode = e.target.value;
+                        }}
+                    ></sp-textfield>
+                    <sp-field-label for="create-title">Title</sp-field-label>
+                    <sp-textfield
+                        id="create-title"
+                        placeholder="e.g. Acrobat"
+                        .value=${this.createDialogTitle}
+                        ?disabled=${this.createDialogBusy}
+                        @input=${(e) => {
+                            this.createDialogTitle = e.target.value;
+                        }}
+                    ></sp-textfield>
+                </div>
+            </sp-dialog-wrapper>
+        `;
+    }
+
     render() {
         if (this.readonly) {
             return this.readonlyTags;
@@ -989,7 +1091,21 @@ class AemTagPickerField extends LitElement {
                         </sp-dialog>
                     </sp-popover>
                 </overlay-trigger>
+                ${this.allowCreate
+                    ? html`
+                          <sp-action-button
+                              aria-label="Create product code tag"
+                              title="Create product code tag"
+                              ?disabled=${this.disabled}
+                              @click=${this.#openCreateDialog}
+                          >
+                              <sp-icon-add size="m" slot="icon"></sp-icon-add>
+                              Create
+                          </sp-action-button>
+                      `
+                    : nothing}
             </sp-tags>
+            ${this.createDialog}
         `;
     }
 }

--- a/studio/src/editors/merch-card-editor.js
+++ b/studio/src/editors/merch-card-editor.js
@@ -1339,6 +1339,7 @@ class MerchCardEditor extends LitElement {
                         label="Tags"
                         namespace="/content/cq:tags/mas"
                         multiple
+                        allow-create
                         class="tags-spacing"
                         data-field-state="${this.getTagsFieldState()}"
                         value="${(this.fragment.newTags || this.fragment.tags.map((tag) => tag.id)).join(',')}"

--- a/studio/test/aem-tag-picker-field.test.js
+++ b/studio/test/aem-tag-picker-field.test.js
@@ -1,8 +1,16 @@
 import { expect, fixture, html } from '@open-wc/testing';
+import { stub } from 'sinon';
 import '../src/swc.js';
 import '../src/aem/aem-tag-picker-field.js';
-import { TAG_COMPARE_CHART, TAG_COMPARE_CHART_PATH, TAG_MERCH_CARD, TAG_MERCH_CARD_COLLECTION } from '../src/constants.js';
+import {
+    AEM_TAG_PATH_PRODUCT_CODE_ROOT,
+    TAG_COMPARE_CHART,
+    TAG_COMPARE_CHART_PATH,
+    TAG_MERCH_CARD,
+    TAG_MERCH_CARD_COLLECTION,
+} from '../src/constants.js';
 import { blockTagCacheLoading, resetTagCache, seedTagCache } from './helpers/tag-cache.js';
+import { UserFriendlyError } from '../src/utils.js';
 
 describe('AemTagPickerField', () => {
     const namespace = '/content/cq:tags/mas';
@@ -68,5 +76,167 @@ describe('AemTagPickerField', () => {
         `);
 
         expect(el.selectedTags).to.deep.equal([]);
+    });
+
+    describe('allow-create (product code tag creation)', () => {
+        let el;
+
+        beforeEach(async () => {
+            el = await fixture(html` <aem-tag-picker-field namespace=${namespace} allow-create></aem-tag-picker-field>`);
+            await el.loadTags();
+            await el.updateComplete;
+        });
+
+        it('renders a Create button when allow-create is set in hierarchical mode', () => {
+            const createBtn = el.shadowRoot.querySelector('sp-action-button[aria-label="Create product code tag"]');
+            expect(createBtn).to.exist;
+        });
+
+        it('does not render a Create button without allow-create', async () => {
+            const noCreate = await fixture(html` <aem-tag-picker-field namespace=${namespace}></aem-tag-picker-field>`);
+            await noCreate.loadTags();
+            await noCreate.updateComplete;
+            const createBtn = noCreate.shadowRoot.querySelector('sp-action-button[aria-label="Create product code tag"]');
+            expect(createBtn).to.be.null;
+        });
+
+        it('opens the create dialog when the Create button is clicked', async () => {
+            const createBtn = el.shadowRoot.querySelector('sp-action-button[aria-label="Create product code tag"]');
+            createBtn.click();
+            await el.updateComplete;
+
+            const dialog = el.shadowRoot.querySelector('sp-dialog-wrapper');
+            expect(dialog).to.exist;
+            expect(dialog.open).to.be.true;
+        });
+
+        it('creates a new tag, adds it to the cache, and selects it on confirm', async () => {
+            const newCode = 'newproduct';
+            const newTitle = 'New Product';
+            const expectedPath = `${AEM_TAG_PATH_PRODUCT_CODE_ROOT}/${newCode}`;
+
+            const createTagStub = stub().resolves({});
+            el._AEM = el._AEM || {};
+            // Stub the internal AEM instance's tags.create
+            const aemInstance = el.shadowRoot.querySelector ? el : el;
+            // Access private #aem via the method indirection
+            el.createDialogCode = newCode;
+            el.createDialogTitle = newTitle;
+            el.createDialogOpen = true;
+            await el.updateComplete;
+
+            // Replace fetch so AEM.createTag succeeds
+            const originalFetch = window.fetch;
+            window.fetch = async (url, opts) => {
+                // GET check: tag does not exist
+                if (opts?.method === 'GET' || !opts?.method) {
+                    return { ok: false, status: 404, statusText: 'Not Found' };
+                }
+                // GET csrf token
+                if (url.includes('csrf')) {
+                    return { ok: true, json: async () => ({ token: 'test-token' }) };
+                }
+                // POST create tag
+                return { ok: true, status: 201 };
+            };
+
+            const changedSpy = stub();
+            el.addEventListener('change', changedSpy);
+
+            // Trigger confirm via calling the handler directly (simulates dialog confirm)
+            (await el._AemTagPickerField__handleCreateTag?.()) ?? (await el['#handleCreateTag']?.());
+
+            window.fetch = originalFetch;
+        });
+
+        it('adds tag to cache and auto-selects it after successful creation', async () => {
+            const newCode = 'testcode';
+            const newTitle = 'Test Code';
+            const expectedPath = `${AEM_TAG_PATH_PRODUCT_CODE_ROOT}/${newCode}`;
+            const expectedTagId = `mas:product_code/${newCode}`;
+
+            // Pre-seed code/title
+            el.createDialogCode = newCode;
+            el.createDialogTitle = newTitle;
+
+            // Stub fetch for the AEM calls
+            const originalFetch = window.fetch;
+            window.fetch = async (url, opts) => {
+                if (url.includes('csrf')) {
+                    return { ok: true, json: async () => ({ token: 'tok' }) };
+                }
+                if (!opts?.method || opts.method === 'GET') {
+                    return { ok: false, status: 404 };
+                }
+                return { ok: true, status: 201 };
+            };
+
+            const changeEvents = [];
+            el.addEventListener('change', () => changeEvents.push(true));
+
+            // Call the method that the confirm button triggers
+            el.createDialogOpen = true;
+            await el.updateComplete;
+
+            // Simulate confirm by direct invocation pattern used by the component
+            // We use the dialog's @confirm event
+            const dialog = el.shadowRoot.querySelector('sp-dialog-wrapper');
+            dialog.dispatchEvent(new CustomEvent('confirm', { bubbles: true, composed: true }));
+            // Give async operations time to complete
+            await new Promise((r) => setTimeout(r, 50));
+            await el.updateComplete;
+
+            window.fetch = originalFetch;
+
+            // The cache should have the new tag
+            const { getNamespaceCache } = await import('../src/aem/tag-cache.js');
+            const cache = getNamespaceCache(namespace);
+            expect(cache?.has(expectedPath)).to.be.true;
+            expect(cache?.get(expectedPath)).to.deep.include({ name: newCode, title: newTitle, path: expectedPath });
+
+            // The value should include the new tag id
+            const valueArr = Array.isArray(el.value) ? el.value : (el.value || '').split(',').filter(Boolean);
+            expect(valueArr.some((v) => v === expectedTagId || v === expectedPath)).to.be.true;
+        });
+
+        it('keeps the dialog open and resets busy state when AEM.createTag fails', async () => {
+            const newCode = 'failcode';
+            const newTitle = 'Fail Code';
+
+            el.createDialogCode = newCode;
+            el.createDialogTitle = newTitle;
+            el.createDialogOpen = true;
+            await el.updateComplete;
+
+            const originalFetch = window.fetch;
+            window.fetch = async (url, opts) => {
+                if (url.includes('csrf')) {
+                    return { ok: true, json: async () => ({ token: 'tok' }) };
+                }
+                if (!opts?.method || opts.method === 'GET') {
+                    return { ok: false, status: 404 };
+                }
+                // Simulate failure on POST
+                return { ok: false, status: 500, statusText: 'Server Error' };
+            };
+
+            const dialog = el.shadowRoot.querySelector('sp-dialog-wrapper');
+            dialog.dispatchEvent(new CustomEvent('confirm', { bubbles: true, composed: true }));
+            await new Promise((r) => setTimeout(r, 50));
+            await el.updateComplete;
+
+            window.fetch = originalFetch;
+
+            // Dialog stays open so the user can fix the inputs and retry
+            expect(el.createDialogOpen).to.be.true;
+            // Busy spinner is cleared
+            expect(el.createDialogBusy).to.be.false;
+        });
+
+        it('does not render the create dialog when createDialogOpen is false', async () => {
+            expect(el.createDialogOpen).to.be.false;
+            const dialog = el.shadowRoot.querySelector('sp-dialog-wrapper');
+            expect(dialog).to.be.null;
+        });
     });
 });


### PR DESCRIPTION
* MWPW-190955 — [M@S Usability] Allow authors to add Product Code tags in Studio
* As a super author, I would like to create Product Code tags in Studio
* M@S Studio currently relies on product code tags that already exist in Odin; when a tag does not exist it cannot be added or persisted via the Studio UI, creating an ongoing dependency on engineering/Odin edits
* Enable authors to create and manage product code tags directly in the Studio UI, written to Odin and persisted on save

Resolves: [MWPW-190955](https://jira.corp.adobe.com/browse/MWPW-190955)

**Test URLs** (the before/after pair the harness visually verified):
- Before: https://main--mas-pinata--adobecom.aem.page/web-components/docs/merch-card.html?martech=off
- After: <!-- no verified visual evidence this run — see the run dashboard -->
